### PR TITLE
Fix share_accounter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +367,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "demand-cli"
 version = "0.1.0"
 dependencies = [
@@ -368,6 +388,7 @@ dependencies = [
  "binary_sv2",
  "bitcoin",
  "codec_sv2",
+ "dashmap",
  "demand-share-accounting-ext",
  "demand-sv2-connection",
  "framing_sv2",
@@ -591,6 +612,12 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dashmap = {version = "6.1.0", features = ["inline"]}
 bitcoin = {version = "0.29.1", features = ["serde","rand"]}
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tokio-util = { version = "*", features = ["codec"] }

--- a/src/share_accounter/mod.rs
+++ b/src/share_accounter/mod.rs
@@ -1,11 +1,12 @@
 mod task_manager;
 
-use std::collections::HashMap;
+use std::sync::Arc;
 
 use demand_share_accounting_ext::*;
 use parser::{PoolExtMessages, ShareAccountingMessages};
 use roles_logic_sv2::{mining_sv2::SubmitSharesSuccess, parsers::Mining};
 use task_manager::TaskManager;
+use dashmap::DashMap;
 
 use crate::shared::utils::AbortOnDrop;
 
@@ -16,27 +17,40 @@ pub async fn start(
     up_sender: tokio::sync::mpsc::Sender<PoolExtMessages<'static>>,
 ) -> AbortOnDrop {
     let task_manager = TaskManager::initialize();
+    let shares_sent_up = Arc::new(DashMap::with_capacity(100));
     let abortable = task_manager
         .safe_lock(|t| t.get_aborter())
         .unwrap()
         .unwrap();
-    let relay_up_task = relay_up(receiver, up_sender);
+    let relay_up_task = relay_up(receiver, up_sender,shares_sent_up.clone());
     TaskManager::add_relay_up(task_manager.clone(), relay_up_task)
         .await
         .expect("Task Manager failed");
-    let relay_down_task = relay_down(up_receiver, sender);
+    let relay_down_task = relay_down(up_receiver, sender,shares_sent_up.clone());
     TaskManager::add_relay_down(task_manager.clone(), relay_down_task)
         .await
         .expect("Task Manager failed");
     abortable
 }
 
-pub fn relay_up(
+struct ShareSentUp {
+    channel_id: u32,
+    sequence_number: u32,
+}
+
+fn relay_up(
     mut receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
     up_sender: tokio::sync::mpsc::Sender<PoolExtMessages<'static>>,
+    shares_sent_up: Arc<DashMap<u32, ShareSentUp>>,
 ) -> AbortOnDrop {
     let task = tokio::spawn(async move {
         while let Some(msg) = receiver.recv().await {
+            if let Mining::SubmitSharesExtended(m) = &msg {
+                shares_sent_up.insert(m.job_id, ShareSentUp{
+                    channel_id: m.channel_id,
+                    sequence_number: m.sequence_number
+                });
+            };
             let msg = PoolExtMessages::Mining(msg);
             if up_sender.send(msg).await.is_err() {
                 break;
@@ -46,29 +60,21 @@ pub fn relay_up(
     task.into()
 }
 
-pub fn relay_down(
+fn relay_down(
     mut up_receiver: tokio::sync::mpsc::Receiver<PoolExtMessages<'static>>,
     sender: tokio::sync::mpsc::Sender<Mining<'static>>,
+    shares_sent_up: Arc<DashMap<u32, ShareSentUp>>,
 ) -> AbortOnDrop {
     let task = tokio::spawn(async move {
-        let mut shares_sent_up = HashMap::new();
         while let Some(msg) = up_receiver.recv().await {
             match msg {
-                PoolExtMessages::Mining(msg) => {
-                    if let Mining::SubmitSharesExtended(m) = &msg {
-                        shares_sent_up.insert(m.job_id, m.clone());
-                    };
-                    if sender.send(msg).await.is_err() {
-                        break;
-                    }
-                }
                 PoolExtMessages::ShareAccountingMessages(msg) => {
                     if let ShareAccountingMessages::ShareOk(msg) = msg {
                         let job_id_bytes = msg.ref_job_id.to_le_bytes();
                         let job_id = u32::from_le_bytes(job_id_bytes[4..8].try_into().unwrap());
                         let share_sent_up = shares_sent_up
                             .remove(&job_id)
-                            .expect("Pool sent invalid share success");
+                            .expect("Pool sent invalid share success").1;
                         let success = Mining::SubmitSharesSuccess(SubmitSharesSuccess {
                             channel_id: share_sent_up.channel_id,
                             last_sequence_number: share_sent_up.sequence_number,


### PR DESCRIPTION
Share accounter relay_up and relay_down shouldn't be public since we use them with start.
Share accounter should transform ShareOk extension messages from upstream into SubmitShareSuccess messages. In order to do that should intercept SubmitShareExtend on from downstream, and save them. So that when it receive the ShareOk message from downstream it have all the info needed to transform it into SubmitShareSuccess