### PR TITLE
Make version rolling mask configurable in sv1_rolling function

### DIFF
--- a/src/shared/utils.rs
+++ b/src/shared/utils.rs
@@ -35,20 +35,16 @@ impl<T: Send + 'static> From<JoinHandle<T>> for AbortOnDrop {
 /// Select a version rolling mask and min bit count based on the request from the miner.
 /// It copy the behavior from SRI translator
 pub fn sv1_rolling(configure: &sv1_api::client_to_server::Configure) -> (HexU32Be, HexU32Be) {
-    // TODO 0x1FFFE000 should be configured
-    // = 11111111111111110000000000000
-    // this is a reasonable default as it allows all 16 version bits to be used
-    // If the tproxy/pool needs to use some version bits this needs to be configurable
-    // so upstreams can negotiate with downstreams. When that happens this should consider
-    // the min_bit_count in the mining.configure message
-    let version_rollin_mask = configure
-        .version_rolling_mask()
-        .map(|mask| HexU32Be(mask & 0x1FFFE000))
-        .unwrap_or(HexU32Be(0));
-    let version_rolling_min_bit = configure
-        .version_rolling_min_bit_count()
-        .unwrap_or(HexU32Be(0));
-    (version_rollin_mask, version_rolling_min_bit)
+    let pool_mask = std::env::var("POOL_MASK")
+        .map(|val| u32::from_str_radix(&val, 16).unwrap_or(0x1FFFE000))
+        .unwrap_or(0x1FFFE000);
+    let miner_mask = configure.version_rolling_mask().unwrap_or(0xFFFFFFFF);
+    let negotiated_mask = miner_mask & pool_mask;
+    let min_bit_count = configure.version_rolling_min_bit_count().unwrap_or(0);
+    (
+        HexU32Be(negotiated_mask),
+        HexU32Be(min_bit_count),
+    )
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
Fixes #20 
- Replaced the hardcoded version rolling mask (0x1FFFE000) with a configurable mechanism.
- Added support for configuring the pool's mask via the POOL_MASK environment variable.
- Negotiated the mask dynamically between upstream and downstream using bitwise AND.
- Considered the version_rolling_min_bit_count from the mining.configure message.