### PR TITLE
Implement `From<V1ProtocolError>` for Error

### DIFF
--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -235,7 +235,6 @@ impl Downstream {
         message_sv1: json_rpc::Message,
     ) -> Result<(), super::super::error::Error<'static>> {
         // `handle_message` in `IsServer` trait + calls `handle_request`
-        // TODO: Map err from V1Error to Error::V1Error
 
         let response = self_.safe_lock(|s| s.handle_message(message_sv1.clone()))?;
         match response {
@@ -256,7 +255,7 @@ impl Downstream {
             }
             Err(e) => {
                 error!("{e}");
-                Err(Error::V1Protocol(e))
+                Err(e.into())
             }
         }
     }

--- a/src/translator/error.rs
+++ b/src/translator/error.rs
@@ -78,3 +78,9 @@ impl From<roles_logic_sv2::Error> for Error<'_> {
         Self::RolesSv2Logic(value)
     }
 }
+
+impl<'a> From<sv1_api::error::Error<'a>> for Error<'a> {
+    fn from(value: sv1_api::error::Error<'a>) -> Self {
+        Self::V1Protocol(value)
+    }
+}

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -327,7 +327,7 @@ impl Bridge {
             // regarding version masking see https://github.com/slushpool/stratumprotocol/blob/master/stratum-extensions.mediawiki#changes-in-request-miningsubmit
             (Some(vb), Some(mask)) => (last_version & !mask.0) | (vb.0 & mask.0),
             (None, None) => last_version,
-            _ => return Err(Error::V1Protocol(sv1_api::error::Error::InvalidSubmission)),
+            _ => return Err(sv1_api::error::Error::InvalidSubmission.into()),
         };
         let mining_device_extranonce: Vec<u8> = sv1_submit.extra_nonce2.into();
         let extranonce2 = mining_device_extranonce;


### PR DESCRIPTION
This PR addresses [TODO](https://github.com/demand-open-source/demand-cli/blob/master/src/translator/downstream/downstream.rs#L238) in the codebase
Mapped error from V1ProtocolError to Error::V1Protocol
