### PR TITLE
Fix no template id that match valid share

### DIFF
--- a/src/jd_client/mining_upstream/upstream.rs
+++ b/src/jd_client/mining_upstream/upstream.rs
@@ -1,3 +1,4 @@
+use crate::jd_client::IS_CUSTOM_JOB_SET;
 use crate::proxy_state::{DownstreamType, ProxyState, TpState, UpstreamType};
 use crate::{jd_client::error::Error, jd_client::error::ProxyResult, shared::utils::AbortOnDrop};
 
@@ -577,6 +578,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
         if let Some(template_id) = self.template_to_job_id.take_template_id(m.request_id) {
             self.template_to_job_id
                 .register_job_id(template_id, m.job_id);
+            IS_CUSTOM_JOB_SET.store(true, std::sync::atomic::Ordering::Release);
             Ok(SendTo::None(None))
         } else {
             error!("Attention received a SetupConnectionSuccess with unknown request_id");

--- a/src/jd_client/mod.rs
+++ b/src/jd_client/mod.rs
@@ -38,6 +38,8 @@ use tracing::{error, info};
 ///    between all the contexts is not necessary.
 pub static IS_NEW_TEMPLATE_HANDLED: AtomicBool = AtomicBool::new(true);
 
+pub static IS_CUSTOM_JOB_SET: AtomicBool = AtomicBool::new(true);
+
 use crate::proxy_state::{DownstreamType, ProxyState, TpState};
 use roles_logic_sv2::{parsers::Mining, utils::Mutex};
 use std::{

--- a/src/jd_client/template_receiver/mod.rs
+++ b/src/jd_client/template_receiver/mod.rs
@@ -346,6 +346,7 @@ impl TemplateRx {
                                                 // template message
                                                 let transactions_data = m.transaction_list;
                                                 let excess_data = m.excess_data;
+                                                let expected_template_id = m.template_id;
                                                 let m = match self_mutex
                                                     .safe_lock(|t| t.new_template_message.clone())
                                                 {
@@ -359,6 +360,9 @@ impl TemplateRx {
                                                         break;
                                                     }
                                                 };
+                                                if m.template_id != expected_template_id {
+                                                    continue;
+                                                }
                                                 let token = last_token.unwrap().unwrap();
                                                 last_token = None;
                                                 let mining_token = token.mining_job_token.to_vec();


### PR DESCRIPTION
There are several things that can result in the above issue:
1. TP send too many new templates and we process a newer template before and older have been processed but we receive the share for the older that will never have a mathcing template id since will be discarded
2. upstream take more then 10 second to authorize a job but we find a valid share right after the we see the template.

This commmit add a lock so that we can not process newer templates until old one have ben declared and acceted. It also make sure that we are not going to process 2 templates that are sent within a very short amount of time (we only get the newer).

It increase the maximum amount of time to get the template id from 10 to 15 sec.

It do not return an Irrecoverable error if we are not able to get the template id within 15 sec from when the share have been received. But it only log that we have a stale share.