### PR TITLE
Add support for solo mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "demand-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-recursion",
  "axum",
@@ -532,6 +532,7 @@ dependencies = [
  "demand-sv2-connection",
  "framing_sv2",
  "futures",
+ "hex",
  "jemallocator",
  "key-utils",
  "lazy_static",
@@ -547,6 +548,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -606,6 +608,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fnv"
@@ -765,6 +773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +875,16 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1412,6 +1436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1661,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1922,6 +1989,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]
@@ -18,28 +18,12 @@ tracing-subscriber = { version = "*", features = ["env-filter"]}
 tokio = {version="^1.36.0",features = ["full","tracing", "macros","rt-multi-thread"]}
 key-utils = "1.0.0"
 pid = { version = "4.0.0"}
-clap = {version = "4.5.31", features = ["derive"]}
-axum = {version = "0.8.1"}
+clap = { version = "4.5.31", features = ["derive"]}
+axum = { version = "0.8.1"}
 serde = { version = "1.0.219", features = ["derive"] }  
 sysinfo = {version = "0.33.1"}
-#roles_logic_sv2 = "1.2.1"
-#sv1_api = "1.0.1"
-#demand-sv2-connection = "0.0.3"
-#framing_sv2 = "^2.0.0"
-#binary_sv2 = "1.1.0"
-#demand-share-accounting-ext = "0.0.10"
-
-#noise_sv2 = "1.1.0"
-#codec_sv2 = { version = "1.2.1", features = ["noise_sv2","with_buffer_pool"]}
-
-#demand-share-accounting-ext = {path = "../demand-share-accounting-ext"}
-#demand-sv2-connection = { path = "../demand-sv2-connection"}
-#roles_logic_sv2 = { path = "../stratum/protocols/v2/roles-logic-sv2"}
-#framing_sv2 = { path = "../stratum/protocols/v2/framing-sv2"}
-#binary_sv2 = { path = "../stratum/protocols/v2/binary-sv2/binary-sv2"}
-#noise_sv2 = {path ="../stratum/protocols/v2/noise-sv2"}
-#codec_sv2 = {features = ["noise_sv2","with_buffer_pool"], path = "../stratum/protocols/v2/codec-sv2" }
-#sv1_api = {path = "../stratum/protocols/v1" }
+toml = { version = "0.8" }
+hex = { version = "0.4.3" }
 
 demand-share-accounting-ext = { git = "https://github.com/demand-open-source/share-accounting-ext"}
 demand-sv2-connection = {git = "https://github.com/demand-open-source/demand-sv2-connection"}
@@ -49,9 +33,6 @@ binary_sv2 = { git = "https://github.com/demand-open-source/stratum", branch ="I
 noise_sv2 = { git = "https://github.com/demand-open-source/stratum", branch="ImproveCoinbase",subdirectory = "protocols/v2/noise-sv2"}
 codec_sv2 = { git = "https://github.com/demand-open-source/stratum", branch="ImproveCoinbase",subdirectory = "protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool"]}
 sv1_api = { git = "https://github.com/demand-open-source/stratum", branch = "ImproveCoinbase",subdirectory = "protocols/v1"}
-
-
-
 
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 [![Forks](https://img.shields.io/github/forks/demand-open-source/demand-cli?style=social)](https://github.com/demand-open-source/demand-cli)
 ![Release](https://img.shields.io/github/v/release/demand-open-source/demand-cli)
 
-**Demand CLI** is a proxy that let miners to connect to and mine with [Demand Pool](https://dmnd.work). It serves two primary purposes: 
+**Demand CLI** is a proxy that let miners to connect to and mine with [Demand Pool](https://dmnd.work). It serves three primary purposes: 
   1. Translation: Enables miners using StratumV1 to connect to the Demand Pool without requiring firmware updates. Sv1 messages gets translated to Sv2.
   2. Job Declaration (JD): Allows miners to declare custom jobs to the pool using StratumV2.
+  3. Solo Mining: Skip pool entirely and mine solo
 
 
 ## Features
 - **Stratum V2 Support**: Uses the secure and efficient Stratum V2 protocol for communication with the pool.
 - **Job Declaration**: Enables miners to propose custom block templates to the pool. This helps make mining more decentralized by allowing miners to pick the transactions they want to include in a block.
 - **Stratum V1 Translation**: Acts as a bridge, allowing StratumV1 miners to connect to the Demand Pool without firmware updates.
+- **Solo Mining Mode**: Allows miners to mine independently without a pool. 
 - **Flexible Configuration**: Provides options for customization. This allows users to optimize the tool for their specific mining environment.
 - **Monitoring API**: Provides HTTP endpoints to monitor proxy health, pool connectivity, miner performace, and system resource usage in real-time.
 
@@ -64,10 +66,20 @@ Before running the CLI, set up the necessary environment variables.
   ```
 Note: if `TP_ADDRESS` id not set, job declaration is disabled, and the proxy uses  templates provided by the pool.
 
+### Config File (for Solo Mining)
+Create config.toml with your coinbase outputs. Supported script types include P2PKH, P2SH, P2WPKH, P2WSH,  and P2TR
+Example config file:
+```toml
+ coinbase_outputs = [
+    { output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" }
+]
+withhold = false
+```
+
 ## Running the CLI
 
 Depending on whether you built from source or downloaded a binary, the command to run the proxy is slightly different. There are also different options you can use. 
-Below are two example setups to get you started.
+Below are 3 example setups to get you started.
 
 #### Example 1: Built from Source with Job Declaration
 
@@ -75,7 +87,7 @@ This example assumes you’ve built `demand-cli` from source and want to enable 
 
    ```bash
    export TOKEN=abc123xyz
-   export TP_ADDRESS=192.168.1.100:8442
+   export TP_ADDRESS=127.0.0.1:8442
    ./target/release/demand-cli -d 100T --loglevel debug --nc on
   ```
 
@@ -92,6 +104,15 @@ Set Environment Variable:
 
 Point your Stratum V1 miners  to <your_proxy_ip>:32767.
 
+Example 3: Solo Mining (No Pool, No TOKEN)
+```bash
+ export TP_ADDRESS=127.0.0.1:8442
+./demand-cli-linux-x64 --solo -c path/to/config.toml --loglevel debug
+```
+This runs in solo mode, using your config.toml to define the coinbase output and other parameters. if `config.toml` is the directory as your binary `-c` is not required. Ensure Bitcoin node is running.
+
+Point your Stratum V1 miners  to <your_proxy_ip>:32767
+
 ### Options
 
   - **`--test`**: Connects to test endpoint
@@ -99,6 +120,8 @@ Point your Stratum V1 miners  to <your_proxy_ip>:32767.
     This helps the pool adjust to your hashrate.
   - **`--loglevel`**: Logging verbosity (`info`, `debug`, `error`, `warn`). Default is `info`.
   - **`--nc`**: Noise connection logging verbosity (`info`, `debug`, `error`, `warn`). Default is `off`.
+  - **`--solo`**: Enable solo mining mode. Requires `TP_ADDRESS` and a config file.
+  - **`-c, --config`**: Path to your solo mining config.toml. Default is config.toml
 
 
 ## Monitoring API:
@@ -153,6 +176,15 @@ Point your Stratum V1 miners  to <your_proxy_ip>:32767.
       "data": {
         "address": "<pool_address>",
         "latency": "5072"
+      }
+    }
+    ```
+  - **200 OK** (Solo mining):
+    ```json
+    {
+      "success": true,
+      "data": {
+        "pool": "Not connected to pool. Mining solo :)",
       }
     }
     ```

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,11 +9,11 @@ use stats::StatsSender;
 // Holds shared state (like the router) that so that it can be accessed in all routes.
 #[derive(Clone)]
 pub struct AppState {
-    router: Router,
+    router: Option<Router>,
     stats_sender: StatsSender,
 }
 
-pub(crate) async fn start(router: Router, stats_sender: StatsSender) {
+pub(crate) async fn start(router: Option<Router>, stats_sender: StatsSender) {
     let state = AppState {
         router,
         stats_sender,

--- a/src/jd_client/mod.rs
+++ b/src/jd_client/mod.rs
@@ -6,14 +6,18 @@ pub mod mining_downstream;
 pub mod mining_upstream;
 mod task_manager;
 mod template_receiver;
+mod utils;
 
+use bitcoin::TxOut;
 use job_declarator::JobDeclarator;
 use key_utils::Secp256k1PublicKey;
 use mining_downstream::DownstreamMiningNode;
-use std::sync::atomic::AtomicBool;
+use roles_logic_sv2::template_distribution_sv2::SubmitSolution;
+use std::{path::PathBuf, sync::atomic::AtomicBool};
 use task_manager::TaskManager;
 use template_receiver::TemplateRx;
 use tracing::{error, info};
+use utils::{get_coinbase_output, parse_tp_address, retry_connection, Config};
 
 /// Is used by the template receiver and the downstream. When a NewTemplate is received the context
 /// that is running the template receiver set this value to false and then the message is sent to
@@ -40,7 +44,7 @@ pub static IS_NEW_TEMPLATE_HANDLED: AtomicBool = AtomicBool::new(true);
 
 pub static IS_CUSTOM_JOB_SET: AtomicBool = AtomicBool::new(true);
 
-use crate::proxy_state::{DownstreamType, ProxyState, TpState};
+use crate::proxy_state::{DownstreamType, ProxyState};
 use roles_logic_sv2::{parsers::Mining, utils::Mutex};
 use std::{
     net::{IpAddr, SocketAddr},
@@ -64,204 +68,241 @@ pub async fn start(
     initialize_jd(receiver, sender, up_receiver, up_sender).await
 }
 
+/// Initializes JD in pool mining mode.
 async fn initialize_jd(
     receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
     sender: tokio::sync::mpsc::Sender<Mining<'static>>,
     up_receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
     up_sender: tokio::sync::mpsc::Sender<Mining<'static>>,
 ) -> Option<AbortOnDrop> {
-    let task_manager = TaskManager::initialize();
-    let abortable = match task_manager.safe_lock(|t| t.get_aborter()) {
-        Ok(abortable) => abortable?,
-        Err(e) => {
-            error!("Jdc task manager mutex corrupt: {e}");
-            return None;
-        }
-    };
-    let test_only_do_not_send_solution_to_tp = false;
-
-    // When Downstream receive a share that meets bitcoin target it transformit in a
-    // SubmitSolution and send it to the TemplateReceiver
-    let (send_solution, recv_solution) = tokio::sync::mpsc::channel(10);
-
-    // Instantiate a new `Upstream` (SV2 Pool)
-    let upstream = match mining_upstream::Upstream::new(crate::MIN_EXTRANONCE_SIZE, up_sender).await
-    {
-        Ok(upstream) => upstream,
-        Err(e) => {
-            error!("Failed to instantiate new Upstream: {e}");
-            drop(abortable);
-            return None;
-        }
-    };
-
-    // Initialize JD part
-    let tp_address = match crate::TP_ADDRESS.safe_lock(|tp| tp.clone()) {
-        Ok(tp_address) => tp_address
-            .expect("Unreachable code, jdc is not instantiated when TP_ADDRESS not present"),
-        Err(e) => {
-            error!("TP_ADDRESS mutex corrupted: {e}");
-            drop(abortable);
-            return None;
-        }
-    };
-
-    let mut parts = tp_address.split(':');
-    let ip_tp = parts.next().expect("The passed value for TP address is not valid. Terminating.... TP_ADDRESS should be in this format `127.0.0.1:8442`").to_string();
-    let port_tp = parts.next().expect("The passed value for TP address is not valid. Terminating.... TP_ADDRESS should be in this format `127.0.0.1:8442`").parse::<u16>().expect("This operation should not fail because a valid port_tp should always be converted to U16");
-
-    let auth_pub_k: Secp256k1PublicKey = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
-    let address = crate::POOL_ADDRESS
-        .to_socket_addrs()
-        .expect("The passed Pool Address is not valid")
-        .next()?;
-
-    let (jd, jd_abortable) =
-        match JobDeclarator::new(address, auth_pub_k.into_bytes(), upstream.clone(), true).await {
-            Ok(c) => c,
-            Err(e) => {
-                error!("Failed to intialize Jd: {e}");
-                drop(abortable);
-                return None;
-            }
-        };
-
-    if TaskManager::add_job_declarator_task(task_manager.clone(), jd_abortable)
+    let (jd, recv_solution) = JdSetUp::new()
+        .await?
+        .start_upstream_and_jd(up_sender, up_receiver)
+        .await?
+        .start_downstream(receiver, sender, None, vec![])
+        .await?;
+    jd.start_template_receiver(recv_solution, vec![], false)
         .await
-        .is_err()
-    {
-        error!(
-            "Task manager failed while trying to add job declarator task{}",
-            error::Error::TaskManagerFailed
-        );
-        drop(abortable);
-        return None;
-    };
-
-    let donwstream = Arc::new(Mutex::new(DownstreamMiningNode::new(
-        sender,
-        Some(upstream.clone()),
-        send_solution,
-        false,
-        vec![],
-        Some(jd.clone()),
-    )));
-    let downstream_abortable = match DownstreamMiningNode::start(donwstream.clone(), receiver).await
-    {
-        Ok(abortable) => abortable,
-        Err(e) => {
-            error!("Can not start downstream mining node: {e}");
-            ProxyState::update_downstream_state(DownstreamType::JdClientMiningDownstream);
-            return None;
-        }
-    };
-    if TaskManager::add_mining_downtream_task(task_manager.clone(), downstream_abortable)
-        .await
-        .is_err()
-    {
-        error!(
-            "Task manager failed while trying to add mining downstream task{}",
-            error::Error::TaskManagerFailed
-        );
-        drop(abortable);
-        return None;
-    };
-    if upstream
-        .safe_lock(|u| u.downstream = Some(donwstream.clone()))
-        .is_err()
-    {
-        error!("Upstream mutex failed");
-        drop(abortable); // drop all tasks initailzed upto this point
-        return None;
-    };
-
-    // Start receiving messages from the SV2 Upstream role
-    let upstream_abortable =
-        match mining_upstream::Upstream::parse_incoming(upstream.clone(), up_receiver).await {
-            Ok(abortable) => abortable,
-            Err(e) => {
-                error!("Failed to get jdc upstream abortable: {e}");
-                drop(abortable); // drop all tasks initailzed upto this point
-                return None;
-            }
-        };
-    if TaskManager::add_mining_upstream_task(task_manager.clone(), upstream_abortable)
-        .await
-        .is_err()
-    {
-        error!(
-            "Task manager failed while trying to add mining upstream task{}",
-            error::Error::TaskManagerFailed
-        );
-        drop(abortable); // drop all tasks initailzed upto this point
-        return None;
-    };
-    let ip = IpAddr::from_str(ip_tp.as_str())
-        .expect("Infallable Operation: Failed tp can always be converted into IpAddr");
-    let tp_abortable = match TemplateRx::connect(
-        SocketAddr::new(ip, port_tp),
-        recv_solution,
-        Some(jd.clone()),
-        donwstream.clone(),
-        vec![],
-        None,
-        test_only_do_not_send_solution_to_tp,
-    )
-    .await
-    {
-        Ok(abortable) => abortable,
-        Err(_) => {
-            info!("Dropping jd abortable");
-            eprintln!("TP is unreachable, the proxy is in not in JD mode");
-            drop(abortable);
-            // Temporaily set TP_ADDRESS to None so that proxy can restart without it.
-            // that means we will start mining without jd
-            if crate::TP_ADDRESS.safe_lock(|tp| *tp = None).is_err() {
-                error!("TP_ADDRESS mutex corrupt");
-                return None;
-            };
-            tokio::spawn(retry_connection(tp_address));
-            return None;
-        }
-    };
-
-    if TaskManager::add_template_receiver_task(task_manager, tp_abortable)
-        .await
-        .is_err()
-    {
-        error!(
-            "Task manager failed while trying to add template receiver task{}",
-            error::Error::TaskManagerFailed
-        );
-        drop(abortable);
-        return None;
-    };
-    Some(abortable)
 }
 
-// Used when tp is down or connection was unsuccessful to retry connection.
-async fn retry_connection(address: String) {
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
-    loop {
-        info!("TP Retrying connection....");
-        interval.tick().await;
-        if tokio::net::TcpStream::connect(address.clone())
+/// Initializes JD in solo mining mode.
+pub async fn initialize_jd_as_solo_miner(
+    receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
+    sender: tokio::sync::mpsc::Sender<Mining<'static>>,
+    config: PathBuf,
+) -> Option<AbortOnDrop> {
+    info!("Starting solo mining...");
+    let config_str = std::fs::read_to_string(config).expect("Failed to read config file");
+    let config: Config = toml::from_str(&config_str).expect("Failed to parse config file");
+    let miner_coinbase_output = get_coinbase_output(&config).unwrap();
+
+    let (jd_solo, recv_solution) = JdSetUp::new()
+        .await?
+        .start_downstream(
+            receiver,
+            sender,
+            config.withhold(),
+            miner_coinbase_output.clone(),
+        )
+        .await?;
+
+    jd_solo
+        .start_template_receiver(recv_solution, miner_coinbase_output, false)
+        .await
+}
+
+struct JdSetUp {
+    task_manager: Arc<Mutex<TaskManager>>,
+    abortable: AbortOnDrop,
+    downstream: Option<Arc<Mutex<DownstreamMiningNode>>>,
+    upstream: Option<Arc<Mutex<mining_upstream::Upstream>>>,
+    jd: Option<Arc<Mutex<JobDeclarator>>>,
+}
+
+impl JdSetUp {
+    async fn new() -> Option<Self> {
+        let task_manager = TaskManager::initialize();
+        let abortable = match task_manager.safe_lock(|t| t.get_aborter()) {
+            Ok(abortable) => abortable?,
+            Err(e) => {
+                error!("Jdc task manager mutex corrupt: {e}");
+                return None;
+            }
+        };
+        Some(Self {
+            task_manager,
+            abortable,
+            downstream: None,
+            upstream: None,
+            jd: None,
+        })
+    }
+
+    async fn start_upstream_and_jd(
+        mut self,
+        up_sender: tokio::sync::mpsc::Sender<Mining<'static>>,
+        up_receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
+    ) -> Option<Self> {
+        let upstream =
+            match mining_upstream::Upstream::new(crate::MIN_EXTRANONCE_SIZE, up_sender).await {
+                Ok(upstream) => upstream,
+                Err(e) => {
+                    error!("Failed to instantiate new Upstream: {e}");
+                    drop(self.abortable);
+                    return None;
+                }
+            };
+
+        let upstream_abortable =
+            match mining_upstream::Upstream::parse_incoming(upstream.clone(), up_receiver).await {
+                Ok(abortable) => abortable,
+                Err(e) => {
+                    error!("Failed to get jdc upstream abortable: {e}");
+                    drop(self.abortable);
+                    return None;
+                }
+            };
+
+        if TaskManager::add_mining_upstream_task(self.task_manager.clone(), upstream_abortable)
             .await
-            .is_ok()
+            .is_err()
         {
-            info!("Successfully reconnected to TP: Restarting Proxy...");
-            if crate::TP_ADDRESS
-                .safe_lock(|tp| *tp = Some(address))
+            error!("Failed to add mining upstream task");
+            drop(self.abortable);
+            return None;
+        };
+        let address = crate::POOL_ADDRESS
+            .to_socket_addrs()
+            .expect("The passed Pool Address is not valid")
+            .next()?;
+        let auth_pub_k: Secp256k1PublicKey =
+            crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
+
+        let (jd, jd_abortable) = match JobDeclarator::new(
+            address,
+            auth_pub_k.into_bytes(),
+            upstream.clone(),
+            true,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                error!("Failed to initialize Jd: {e}");
+                drop(self.abortable);
+                return None;
+            }
+        };
+
+        if TaskManager::add_job_declarator_task(self.task_manager.clone(), jd_abortable)
+            .await
+            .is_err()
+        {
+            error!("Failed to add job declarator task");
+            drop(self.abortable);
+            return None;
+        };
+        self.upstream = Some(upstream);
+        self.jd = Some(jd);
+        Some(self)
+    }
+
+    async fn start_downstream(
+        mut self,
+        receiver: tokio::sync::mpsc::Receiver<Mining<'static>>,
+        sender: tokio::sync::mpsc::Sender<Mining<'static>>,
+        withhold: Option<bool>,
+        miner_coinbase_output: Vec<TxOut>,
+    ) -> Option<(Self, tokio::sync::mpsc::Receiver<SubmitSolution<'static>>)> {
+        let (send_solution, recv_solution) = tokio::sync::mpsc::channel(10);
+
+        let downstream = Arc::new(Mutex::new(DownstreamMiningNode::new(
+            sender,
+            self.upstream.clone(),
+            send_solution,
+            withhold.unwrap_or(false),
+            miner_coinbase_output,
+            self.jd.clone(),
+        )));
+
+        let downstream_abortable =
+            match DownstreamMiningNode::start(downstream.clone(), receiver).await {
+                Ok(abortable) => abortable,
+                Err(e) => {
+                    error!("Cannot start downstream mining node: {e}");
+                    ProxyState::update_downstream_state(DownstreamType::JdClientMiningDownstream);
+                    drop(self.abortable);
+                    return None;
+                }
+            };
+
+        if TaskManager::add_mining_downtream_task(self.task_manager.clone(), downstream_abortable)
+            .await
+            .is_err()
+        {
+            error!("Failed to add mining downstream task");
+            drop(self.abortable);
+            return None;
+        };
+
+        if let Some(upstream) = &self.upstream {
+            if upstream
+                .safe_lock(|u| u.downstream = Some(downstream.clone()))
                 .is_err()
             {
-                error!("TP_ADDRESS Mutex failed");
-                std::process::exit(1);
+                error!("Upstream mutex failed");
+                drop(self.abortable);
+                return None;
             };
-            // This force the proxy to restart. If we use Up the proxy just ignore it.
-            // So updating it to Down and setting the TP_ADDRESS to Some(address) will make the
-            // proxy restart with TP, the the TpState will be set to Up.
-            ProxyState::update_tp_state(TpState::Down);
-            break;
+        }
+
+        self.downstream = Some(downstream);
+        Some((self, recv_solution))
+    }
+
+    async fn start_template_receiver(
+        self,
+        recv_solution: tokio::sync::mpsc::Receiver<SubmitSolution<'static>>,
+        miner_coinbase_tx: Vec<TxOut>,
+        test_only_do_not_send_solution_to_tp: bool,
+    ) -> Option<AbortOnDrop> {
+        let (ip_tp, port_tp, tp_address) = parse_tp_address()?;
+
+        let ip = IpAddr::from_str(ip_tp.as_str()).expect("Invalid IP address");
+
+        match TemplateRx::connect(
+            SocketAddr::new(ip, port_tp),
+            recv_solution,
+            self.jd,
+            self.downstream.expect("Downstream must be initialized"),
+            miner_coinbase_tx,
+            None,
+            test_only_do_not_send_solution_to_tp,
+        )
+        .await
+        {
+            Ok(tp_abortable) => {
+                if TaskManager::add_template_receiver_task(self.task_manager, tp_abortable)
+                    .await
+                    .is_err()
+                {
+                    error!("Failed to add template receiver task");
+                    drop(self.abortable);
+                    return None;
+                }
+                Some(self.abortable)
+            }
+            Err(_) => {
+                info!("Dropping jd abortable");
+                eprintln!("TP is unreachable, the proxy is in not in JD mode");
+                drop(self.abortable);
+                if crate::TP_ADDRESS.safe_lock(|tp| *tp = None).is_err() {
+                    error!("TP_ADDRESS mutex corrupt");
+                    return None;
+                };
+                tokio::spawn(retry_connection(tp_address));
+                None
+            }
         }
     }
 }

--- a/src/jd_client/utils.rs
+++ b/src/jd_client/utils.rs
@@ -1,0 +1,97 @@
+use bitcoin::TxOut;
+use roles_logic_sv2::{utils::CoinbaseOutput, Error};
+use serde::Deserialize;
+use tracing::{error, info};
+
+use crate::proxy_state::{ProxyState, TpState};
+
+// Used when tp is down or connection was unsuccessful to retry connection.
+pub async fn retry_connection(address: String) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+    loop {
+        info!("TP Retrying connection....");
+        interval.tick().await;
+        if tokio::net::TcpStream::connect(address.clone())
+            .await
+            .is_ok()
+        {
+            info!("Successfully reconnected to TP: Restarting Proxy...");
+            if crate::TP_ADDRESS
+                .safe_lock(|tp| *tp = Some(address))
+                .is_err()
+            {
+                error!("TP_ADDRESS Mutex failed");
+                std::process::exit(1);
+            };
+            // This force the proxy to restart. If we use Up the proxy just ignore it.
+            // So updating it to Down and setting the TP_ADDRESS to Some(address) will make the
+            // proxy restart with TP, the the TpState will be set to Up.
+            ProxyState::update_tp_state(TpState::Down);
+            break;
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct Output {
+    output_script_type: String,
+    output_script_value: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    coinbase_outputs: Vec<Output>,
+    withhold: Option<bool>,
+}
+impl Config {
+    pub fn withhold(self) -> Option<bool> {
+        self.withhold
+    }
+}
+
+impl TryFrom<&Output> for CoinbaseOutput {
+    type Error = Error;
+
+    fn try_from(pool_output: &Output) -> Result<Self, Self::Error> {
+        match pool_output.output_script_type.as_str() {
+            "P2PK" | "P2PKH" | "P2WPKH" | "P2SH" | "P2WSH" | "P2TR" => Ok(CoinbaseOutput {
+                output_script_type: pool_output.clone().output_script_type,
+                output_script_value: pool_output.clone().output_script_value,
+            }),
+            _ => Err(Error::UnknownOutputScriptType),
+        }
+    }
+}
+
+pub fn get_coinbase_output(config: &Config) -> Result<Vec<TxOut>, Error> {
+    let mut result = Vec::new();
+    for coinbase_output_pool in &config.coinbase_outputs {
+        let coinbase_output: CoinbaseOutput = coinbase_output_pool.try_into()?;
+        let output_script = coinbase_output.try_into()?;
+        result.push(TxOut {
+            value: 0,
+            script_pubkey: output_script,
+        });
+    }
+    match result.is_empty() {
+        true => Err(Error::EmptyCoinbaseOutputs),
+        _ => Ok(result),
+    }
+}
+
+pub fn parse_tp_address() -> Option<(String, u16, String)> {
+    let tp_address = match crate::TP_ADDRESS.safe_lock(|tp| tp.clone()) {
+        Ok(tp_address) => tp_address
+            .expect("Unreachable code, jdc is not instantiated when TP_ADDRESS not present"),
+        Err(e) => {
+            error!("TP_ADDRESS mutex corrupted: {e}");
+            return None;
+        }
+    };
+
+    let mut parts = tp_address.split(':');
+    let ip_tp = parts.next().expect("The passed value for TP address is not valid. Terminating.... TP_ADDRESS should be in this format `127.0.0.1:8442`").to_string();
+    let port_tp = parts.next().expect("The passed value for TP address is not valid. Terminating.... TP_ADDRESS should be in this format `127.0.0.1:8442`").parse::<u16>().expect("This operation should not fail because a valid port_tp should always be converted to U16");
+
+    Some((ip_tp, port_tp, tp_address))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 #[cfg(not(target_os = "windows"))]
 use jemallocator::Jemalloc;
 use router::Router;
+use shared::utils::HashUnit;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
@@ -42,17 +43,13 @@ const TEST_AUTH_PUB_KEY: &str = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7
 const DEFAULT_LISTEN_ADDRESS: &str = "0.0.0.0:32767";
 
 lazy_static! {
+    static ref ARGS: Args = Args::parse();
     static ref SV1_DOWN_LISTEN_ADDR: String =
         std::env::var("SV1_DOWN_LISTEN_ADDR").unwrap_or(DEFAULT_LISTEN_ADDRESS.to_string());
     static ref TP_ADDRESS: roles_logic_sv2::utils::Mutex<Option<String>> =
         roles_logic_sv2::utils::Mutex::new(std::env::var("TP_ADDRESS").ok());
-    static ref EXPECTED_SV1_HASHPOWER: f32 = Args::parse()
-        .downstream_hashrate
-        .unwrap_or(DEFAULT_SV1_HASHPOWER);
-}
-
-lazy_static! {
-    static ref ARGS: Args = Args::parse();
+    static ref EXPECTED_SV1_HASHPOWER: f32 =
+        ARGS.downstream_hashrate.unwrap_or(DEFAULT_SV1_HASHPOWER);
     pub static ref POOL_ADDRESS: &'static str = if ARGS.test {
         TEST_POOL_ADDRESS
     } else {
@@ -69,12 +66,16 @@ struct Args {
     // Use test enpoint if test flag is provided
     #[clap(long)]
     test: bool,
-    #[clap(long ="d", short ='d', value_parser = parse_hashrate)]
+    #[clap(long ="d", short ='d', value_parser = shared::utils::parse_hashrate)]
     downstream_hashrate: Option<f32>,
     #[clap(long = "loglevel", short = 'l', default_value = "info")]
     loglevel: String,
     #[clap(long = "nc", short = 'n', default_value = "off")]
     noise_connection_log: String,
+    #[clap(long = "solo", short = 's')]
+    solo: bool,
+    #[arg(short = 'c', long, default_value = "config.toml")]
+    config: std::path::PathBuf,
 }
 
 #[tokio::main]
@@ -113,41 +114,46 @@ async fn main() {
             log_level, noise_connection_log_level
         )))
         .init();
-    std::env::var("TOKEN").expect("Missing TOKEN environment variable");
 
-    let hashpower = *EXPECTED_SV1_HASHPOWER;
-
-    if args.downstream_hashrate.is_some() {
-        info!(
-            "Using downstream hashrate: {}h/s",
-            HashUnit::format_value(hashpower)
-        );
+    if args.solo {
+        initialize_proxy_solo(args.config).await;
     } else {
-        warn!(
-            "No downstream hashrate provided, using default value: {}h/s",
-            HashUnit::format_value(hashpower)
-        );
+        std::env::var("TOKEN").expect("Missing TOKEN environment variable");
+
+        let hashpower = *EXPECTED_SV1_HASHPOWER;
+
+        if args.downstream_hashrate.is_some() {
+            info!(
+                "Using downstream hashrate: {}h/s",
+                HashUnit::format_value(hashpower)
+            );
+        } else {
+            warn!(
+                "No downstream hashrate provided, using default value: {}h/s",
+                HashUnit::format_value(hashpower)
+            );
+        }
+        if args.test {
+            info!("Connecting to test endpoint...");
+        }
+
+        let auth_pub_k: Secp256k1PublicKey = AUTH_PUB_KEY.parse().expect("Invalid public key");
+        let address = POOL_ADDRESS
+            .to_socket_addrs()
+            .expect("Invalid pool address")
+            .next()
+            .expect("Invalid pool address");
+
+        // We will add upstream addresses here
+        let pool_addresses = vec![address];
+
+        let mut router = router::Router::new(pool_addresses, auth_pub_k, None, None);
+        let epsilon = Duration::from_millis(10);
+        let best_upstream = router.select_pool_connect().await;
+        initialize_proxy(&mut router, best_upstream, epsilon).await;
+        info!("exiting");
+        tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
     }
-    if args.test {
-        info!("Connecting to test endpoint...");
-    }
-
-    let auth_pub_k: Secp256k1PublicKey = AUTH_PUB_KEY.parse().expect("Invalid public key");
-    let address = POOL_ADDRESS
-        .to_socket_addrs()
-        .expect("Invalid pool address")
-        .next()
-        .expect("Invalid pool address");
-
-    // We will add upstream addresses here
-    let pool_addresses = vec![address];
-
-    let mut router = router::Router::new(pool_addresses, auth_pub_k, None, None);
-    let epsilon = Duration::from_millis(10);
-    let best_upstream = router.select_pool_connect().await;
-    initialize_proxy(&mut router, best_upstream, epsilon).await;
-    info!("exiting");
-    tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
 }
 
 async fn initialize_proxy(
@@ -262,8 +268,8 @@ async fn initialize_proxy(
         if let Some(jdc_handle) = jdc_abortable {
             abort_handles.push((jdc_handle, "jdc".to_string()));
         }
-        let server_handle = tokio::spawn(api::start(router.clone(), stats_sender));
-        match monitor(router, abort_handles, epsilon, server_handle).await {
+        let server_handle = tokio::spawn(api::start(Some(router.clone()), stats_sender));
+        match monitor(Some(router), abort_handles, Some(epsilon), server_handle).await {
             Reconnect::NewUpstream(new_pool_addr) => {
                 ProxyState::update_proxy_state_up();
                 pool_addr = Some(new_pool_addr);
@@ -278,10 +284,63 @@ async fn initialize_proxy(
     }
 }
 
+async fn initialize_proxy_solo(config: std::path::PathBuf) {
+    loop {
+        let (downs_sv1_tx, downs_sv1_rx) = channel(10);
+        let sv1_ingress_abortable = ingress::sv1_ingress::start_listen_for_downstream(downs_sv1_tx);
+        let stats_sender = api::stats::StatsSender::new();
+        let (translator_up_tx, mut translator_up_rx) = channel(10);
+        let translator_abortable =
+            match translator::start(downs_sv1_rx, translator_up_tx, stats_sender.clone()).await {
+                Ok(abortable) => abortable,
+                Err(e) => {
+                    error!("Impossible to initialize translator: {e}");
+                    ProxyState::update_translator_state(TranslatorState::Down);
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+            };
+
+        let (jdc_to_translator_sender, jdc_from_translator_receiver, _) = translator_up_rx
+            .recv()
+            .await
+            .expect("Translator failed before initialization");
+
+        let jdc_abortable = match jd_client::initialize_jd_as_solo_miner(
+            jdc_from_translator_receiver,
+            jdc_to_translator_sender,
+            config.clone(),
+        )
+        .await
+        {
+            Some(abortable) => abortable,
+            None => {
+                error!("Impossible to initialize JDC");
+                ProxyState::update_tp_state(TpState::Down);
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                continue;
+            }
+        };
+
+        let abort_handles = vec![
+            (sv1_ingress_abortable, "sv1_ingress".to_string()),
+            (translator_abortable, "translator".to_string()),
+            (jdc_abortable, "jdc".to_string()),
+        ];
+
+        let server_handle = tokio::spawn(api::start(None, stats_sender));
+        if monitor(None, abort_handles, None, server_handle).await == Reconnect::NoUpstream {
+            ProxyState::update_proxy_state_up();
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            continue;
+        }
+    }
+}
+
 async fn monitor(
-    router: &mut Router,
+    mut router: Option<&mut Router>,
     abort_handles: Vec<(AbortOnDrop, std::string::String)>,
-    epsilon: Duration,
+    epsilon: Option<Duration>,
     server_handle: tokio::task::JoinHandle<()>,
 ) -> Reconnect {
     let mut should_check_upstreams_latency = 0;
@@ -289,14 +348,16 @@ async fn monitor(
         // Check if a better upstream exist every 100 seconds
         if should_check_upstreams_latency == 10 * 100 {
             should_check_upstreams_latency = 0;
-            if let Some(new_upstream) = router.monitor_upstream(epsilon).await {
-                info!("Faster upstream detected. Reinitializing proxy...");
-                drop(abort_handles);
-                server_handle.abort(); // abort server
+            if let (Some(router), Some(epsilon)) = (router.as_mut(), epsilon) {
+                if let Some(new_upstream) = router.monitor_upstream(epsilon).await {
+                    info!("Faster upstream detected. Reinitializing proxy...");
+                    drop(abort_handles);
+                    server_handle.abort(); // abort server
 
-                // Needs a little to time to drop
-                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-                return Reconnect::NewUpstream(new_upstream);
+                    // Needs a little to time to drop
+                    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                    return Reconnect::NewUpstream(new_upstream);
+                }
             }
         }
 
@@ -342,80 +403,8 @@ async fn monitor(
     }
 }
 
-/// Parses a hashrate string (e.g., "10T", "2.5P", "500E") into an f32 value in h/s.
-fn parse_hashrate(hashrate_str: &str) -> Result<f32, String> {
-    let hashrate_str = hashrate_str.trim();
-    if hashrate_str.is_empty() {
-        return Err("Hashrate cannot be empty. Expected format: '<number><unit>' (e.g., '10T', '2.5P', '5E'".to_string());
-    }
-
-    let unit = hashrate_str.chars().last().unwrap_or(' ').to_string();
-    let num = &hashrate_str[..hashrate_str.len().saturating_sub(1)];
-
-    let num: f32 = num.parse().map_err(|_| {
-        format!(
-            "Invalid number '{}'. Expected format: '<number><unit>' (e.g., '10T', '2.5P', '5E')",
-            num
-        )
-    })?;
-
-    let multiplier = HashUnit::from_str(&unit)
-        .map(|unit| unit.multiplier())
-        .ok_or_else(|| format!(
-            "Invalid unit '{}'. Expected 'T' (Terahash), 'P' (Petahash), or 'E' (Exahash). Example: '10T', '2.5P', '5E'",
-            unit
-        ))?;
-
-    let hashrate = num * multiplier;
-
-    if hashrate.is_infinite() || hashrate.is_nan() {
-        return Err("Hashrate too large or invalid".to_string());
-    }
-
-    Ok(hashrate)
-}
-
+#[derive(PartialEq)]
 pub enum Reconnect {
     NewUpstream(std::net::SocketAddr), // Reconnecting with a new upstream
     NoUpstream,                        // Reconnecting without upstream
-}
-
-enum HashUnit {
-    Tera,
-    Peta,
-    Exa,
-}
-
-impl HashUnit {
-    /// Returns the multiplier for each unit in h/s
-    fn multiplier(&self) -> f32 {
-        match self {
-            HashUnit::Tera => 1e12,
-            HashUnit::Peta => 1e15,
-            HashUnit::Exa => 1e18,
-        }
-    }
-
-    // Converts a unit string (e.g., "T") to a HashUnit variant
-    fn from_str(s: &str) -> Option<Self> {
-        match s.to_uppercase().as_str() {
-            "T" => Some(HashUnit::Tera),
-            "P" => Some(HashUnit::Peta),
-            "E" => Some(HashUnit::Exa),
-            _ => None,
-        }
-    }
-
-    /// Formats a hashrate value (f32) into a string with the appropriate unit
-    fn format_value(hashrate: f32) -> String {
-        if hashrate >= 1e18 {
-            format!("{:.2}E", hashrate / 1e18)
-        } else if hashrate >= 1e15 {
-            format!("{:.2}P", hashrate / 1e15)
-        } else if hashrate >= 1e12 {
-            format!("{:.2}T", hashrate / 1e12)
-        } else {
-            format!("{:.2}", hashrate)
-        }
-    }
 }

--- a/src/translator/utils.rs
+++ b/src/translator/utils.rs
@@ -108,7 +108,7 @@ pub fn validate_share(
         .0;
     let version = (job_version & !mask) | (request_version & mask);
 
-    let mut hash = roles_logic_sv2::utils::get_target(
+    let hash = roles_logic_sv2::utils::get_target(
         request.nonce.0,
         version,
         request.time.0,
@@ -120,10 +120,13 @@ pub fn validate_share(
         job.bits.0,
     );
 
-    hash.reverse(); //conver to little-endian
+    let mut target = Downstream::difficulty_to_target(difficulty);
+    target.reverse();
+
+    println!("Hash: {:x?}", hex::encode(hash));
+    println!("Target: {:x?}", hex::encode(target));
 
     let hash: Target = hash.into();
-    let target = Downstream::difficulty_to_target(difficulty);
     let target: Target = target.into();
     hash <= target
 }


### PR DESCRIPTION
This PR introduces support for solo mining.

### Changes
- Introduced a new `--solo (-s)` flag to enable solo mode.
- Added support for reading coinbase_outputs from a config.toml file to define payout scripts.
- Introduced `initialize_jd_as_solo_miner` function to start jd_client in solo mode
- Made minor modification to `jd_client` mining downstream to support solo mode
- Updated README file