### PR TITLE
Add Delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "demand-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +136,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
@@ -164,12 +170,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -198,15 +204,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
+name = "base58ck"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "binary_codec_sv2"
 version = "2.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "buffer_sv2",
 ]
@@ -214,22 +230,27 @@ dependencies = [
 [[package]]
 name = "binary_sv2"
 version = "2.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",
- "tracing",
 ]
 
 [[package]]
 name = "bitcoin"
-version = "0.29.2"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
+ "base58ck",
  "bech32",
- "bitcoin_hashes 0.11.0",
- "secp256k1 0.24.3",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -238,6 +259,31 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -250,28 +296,42 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
+ "serde",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -302,11 +362,17 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "1.1.1"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "2.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "aes-gcm",
 ]
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -316,15 +382,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -372,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -382,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -394,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -412,14 +478,15 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codec_sv2"
-version = "1.3.1"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "2.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "const_sv2",
  "framing_sv2",
  "noise_sv2",
+ "rand",
  "tracing",
 ]
 
@@ -431,17 +498,37 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common_messages_sv2"
-version = "2.0.1"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "4.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "const_sv2",
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "const_sv2"
 version = "3.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 
 [[package]]
 name = "core-foundation-sys"
@@ -451,9 +538,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -484,6 +571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +604,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -532,12 +625,14 @@ dependencies = [
  "demand-sv2-connection",
  "framing_sv2",
  "futures",
+ "hex",
  "jemallocator",
  "key-utils",
  "lazy_static",
  "nohash-hasher",
  "noise_sv2",
  "pid",
+ "primitive-types",
  "rand",
  "roles_logic_sv2",
  "serde",
@@ -577,7 +672,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "2.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_codec_sv2",
 ]
@@ -608,6 +703,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,13 +737,19 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "3.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "4.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
  "const_sv2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -733,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -765,6 +884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +906,30 @@ name = "hex-conservative"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "http"
@@ -849,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-util",
@@ -864,10 +1013,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
+name = "impl-codec"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -880,9 +1059,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jemalloc-sys"
@@ -906,8 +1085,8 @@ dependencies = [
 
 [[package]]
 name = "job_declaration_sv2"
-version = "2.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "3.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -915,11 +1094,13 @@ dependencies = [
 
 [[package]]
 name = "key-utils"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e87161774e549722a6bf95fdb9504cbe8a7724b35bcdb9d27c20eff4d4a35c"
+checksum = "ffe8551792fd4461e519fdfd8b8f334d1bf480250786fd202baf418854ff7130"
 dependencies = [
  "bs58",
+ "rand",
+ "rustversion",
  "secp256k1 0.28.2",
  "serde",
 ]
@@ -932,9 +1113,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "lock_api"
@@ -948,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -981,8 +1162,8 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mining_sv2"
-version = "2.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "3.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -990,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1017,7 +1198,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 [[package]]
 name = "noise_sv2"
 version = "1.2.1"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1066,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -1081,6 +1262,34 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1157,30 +1366,56 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "primitive-types"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1234,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1287,17 +1522,19 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roles_logic_sv2"
-version = "3.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "3.1.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "chacha20poly1305",
  "common_messages_sv2",
  "const_sv2",
  "framing_sv2",
+ "hex-conservative 0.3.0",
  "job_declaration_sv2",
  "mining_sv2",
  "nohash-hasher",
+ "primitive-types",
  "siphasher",
  "stratum-common",
  "template_distribution_sv2",
@@ -1311,6 +1548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,27 +1561,15 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "bitcoin_hashes 0.11.0",
- "rand",
- "secp256k1-sys 0.6.1",
- "serde",
-]
 
 [[package]]
 name = "secp256k1"
@@ -1352,12 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
+name = "secp256k1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "cc",
+ "bitcoin_hashes 0.14.0",
+ "rand",
+ "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -1365,6 +1599,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -1391,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1464,9 +1707,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -1488,24 +1731,30 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stratum-common"
 version = "1.0.0"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "bitcoin",
  "secp256k1 0.28.2",
@@ -1526,7 +1775,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "1.0.1"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -1539,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1569,9 +1818,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "template_distribution_sv2"
-version = "1.0.3"
-source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#edf95cfcd8baf9569a195f41488310a958515658"
+version = "3.0.0"
+source = "git+https://github.com/demand-open-source/stratum?branch=ImproveCoinbase#bb4c9743573b567bb1c4254d8b2258b1659a7b78"
 dependencies = [
  "binary_sv2",
  "const_sv2",
@@ -1589,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1608,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1619,15 +1874,32 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1722,15 +1994,33 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -1924,20 +2214,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "winnow"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
- "byteorder",
+ "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 dashmap = {version = "6.1.0", features = ["inline"]}
-bitcoin = {version = "0.29.1", features = ["serde","rand"]}
+bitcoin = {version = "0.32.5", features = ["serde","rand"]}
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tokio-util = { version = "*", features = ["codec"] }
 nohash-hasher = "*"
@@ -22,24 +22,9 @@ clap = {version = "4.5.31", features = ["derive"]}
 axum = {version = "0.8.1"}
 serde = { version = "1.0.219", features = ["derive"] }  
 sysinfo = {version = "0.33.1"}
-#roles_logic_sv2 = "1.2.1"
-#sv1_api = "1.0.1"
-#demand-sv2-connection = "0.0.3"
-#framing_sv2 = "^2.0.0"
-#binary_sv2 = "1.1.0"
-#demand-share-accounting-ext = "0.0.10"
+primitive-types = { version = "0.13.1" }
+hex={version = "*"}
 
-#noise_sv2 = "1.1.0"
-#codec_sv2 = { version = "1.2.1", features = ["noise_sv2","with_buffer_pool"]}
-
-#demand-share-accounting-ext = {path = "../demand-share-accounting-ext"}
-#demand-sv2-connection = { path = "../demand-sv2-connection"}
-#roles_logic_sv2 = { path = "../stratum/protocols/v2/roles-logic-sv2"}
-#framing_sv2 = { path = "../stratum/protocols/v2/framing-sv2"}
-#binary_sv2 = { path = "../stratum/protocols/v2/binary-sv2/binary-sv2"}
-#noise_sv2 = {path ="../stratum/protocols/v2/noise-sv2"}
-#codec_sv2 = {features = ["noise_sv2","with_buffer_pool"], path = "../stratum/protocols/v2/codec-sv2" }
-#sv1_api = {path = "../stratum/protocols/v1" }
 
 demand-share-accounting-ext = { git = "https://github.com/demand-open-source/share-accounting-ext"}
 demand-sv2-connection = {git = "https://github.com/demand-open-source/demand-sv2-connection"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,24 @@ serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = {version = "0.33.1"}
 primitive-types = { version = "0.13.1" }
 hex={version = "*"}
+#roles_logic_sv2 = "1.2.1"
+#sv1_api = "1.0.1"
+#demand-sv2-connection = "0.0.3"
+#framing_sv2 = "^2.0.0"
+#binary_sv2 = "1.1.0"
+#demand-share-accounting-ext = "0.0.10"
 
+#noise_sv2 = "1.1.0"
+#codec_sv2 = { version = "1.2.1", features = ["noise_sv2","with_buffer_pool"]}
+
+#demand-share-accounting-ext = {path = "../demand-share-accounting-ext"}
+#demand-sv2-connection = { path = "../demand-sv2-connection"}
+#roles_logic_sv2 = { path = "../stratum/protocols/v2/roles-logic-sv2"}
+#framing_sv2 = { path = "../stratum/protocols/v2/framing-sv2"}
+#binary_sv2 = { path = "../stratum/protocols/v2/binary-sv2/binary-sv2"}
+#noise_sv2 = {path ="../stratum/protocols/v2/noise-sv2"}
+#codec_sv2 = {features = ["noise_sv2","with_buffer_pool"], path = "../stratum/protocols/v2/codec-sv2" }
+#sv1_api = {path = "../stratum/protocols/v1" }
 
 demand-share-accounting-ext = { git = "https://github.com/demand-open-source/share-accounting-ext"}
 demand-sv2-connection = {git = "https://github.com/demand-open-source/demand-sv2-connection"}

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -24,7 +24,7 @@ pub(super) async fn get_cpu_and_memory_usage() -> (f32, u64) {
     if let Some(process) = system.process(Pid::from_u32(pid)) {
         let cpu_usage = process.cpu_usage();
         let cpu_nums = system.cpus().len() as f32; // get the number of cpu
-        
+
         let normalized_cpu_usage = if cpu_nums > 0.0 {
             cpu_usage / cpu_nums
         } else {

--- a/src/jd_client/error.rs
+++ b/src/jd_client/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use bitcoin::util::uint::ParseLengthError;
+use bitcoin::error::ParseIntError;
 
 pub type ProxyResult<T> = core::result::Result<T, Error>;
 
@@ -27,7 +27,7 @@ pub enum Error {
     // Locking Errors
     PoisonLock,
     TokioChannelErrorRecv(tokio::sync::broadcast::error::RecvError),
-    Uint256Conversion(ParseLengthError),
+    Uint256Conversion(ParseIntError),
     Infallible(std::convert::Infallible),
     Unrecoverable,
     TaskManagerFailed,
@@ -163,8 +163,8 @@ impl From<Vec<u8>> for Error {
     }
 }
 
-impl From<ParseLengthError> for Error {
-    fn from(e: ParseLengthError) -> Self {
+impl From<ParseIntError> for Error {
+    fn from(e: ParseIntError) -> Self {
         Error::Uint256Conversion(e)
     }
 }

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -1,7 +1,7 @@
 pub mod message_handler;
 mod task_manager;
 use binary_sv2::{Seq0255, Seq064K, B016M, B064K, U256};
-use bitcoin::{util::psbt::serialize::Deserialize, Transaction};
+use bitcoin::{blockdata::transaction::Transaction, hashes::Hash};
 use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use demand_sv2_connection::noise_connection_tokio::Connection;
 use roles_logic_sv2::{
@@ -241,9 +241,11 @@ impl JobDeclarator {
         let mut tx_list: Vec<Transaction> = Vec::new();
         let mut tx_ids = vec![];
         for tx in tx_list_.to_vec() {
-            match Transaction::deserialize(&tx) {
+            let transaction: Result<Transaction, bitcoin::consensus::encode::Error> =
+                bitcoin::consensus::deserialize(&tx);
+            match transaction {
                 Ok(tx) => {
-                    let id: U256 = tx.txid().to_vec().try_into().unwrap();
+                    let id: U256 = tx.compute_txid().to_raw_hash().to_byte_array().into();
                     tx_list.push(tx);
                     tx_ids.push(id);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ lazy_static! {
     } else {
         MAIN_AUTH_PUB_KEY
     };
+    static ref DELAY: Duration = Duration::from_secs(ARGS.delay);
 }
 #[derive(Parser)]
 struct Args {
@@ -75,6 +76,8 @@ struct Args {
     loglevel: String,
     #[clap(long = "nc", short = 'n', default_value = "off")]
     noise_connection_log: String,
+    #[clap(long = "delay", default_value = "5")]
+    delay: u64,
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,6 @@ lazy_static! {
     } else {
         MAIN_AUTH_PUB_KEY
     };
-    static ref DELAY: Duration = Duration::from_secs(ARGS.delay);
 }
 #[derive(Parser)]
 struct Args {
@@ -76,7 +75,7 @@ struct Args {
     loglevel: String,
     #[clap(long = "nc", short = 'n', default_value = "off")]
     noise_connection_log: String,
-    #[clap(long = "delay", default_value = "5")]
+    #[clap(long = "delay", default_value = "0")]
     delay: u64,
 }
 

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -1,16 +1,16 @@
 use super::{Downstream, DownstreamMessages, SetDownstreamTarget};
 use pid::Pid;
-use roles_logic_sv2::{self, utils::from_u128_to_uint256};
+use roles_logic_sv2::{self, utils::from_u128_to_u256};
 use sv1_api::{self, methods::server_to_client::SetDifficulty, server_to_client::Notify};
 
 use super::super::error::{Error, ProxyResult};
+use primitive_types::U256;
 use roles_logic_sv2::utils::Mutex;
 use std::ops::{Div, Mul};
 use std::sync::Arc;
 use std::time::Duration;
 use sv1_api::json_rpc;
 
-use bitcoin::util::uint::Uint256;
 use tracing::{error, info};
 
 impl Downstream {
@@ -133,7 +133,7 @@ impl Downstream {
             0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         ];
-        let pdiff = Uint256::from_be_bytes(pdiff);
+        let pdiff = U256::from_big_endian(&pdiff);
         let scale: u128 = 1_000_000;
 
         // To handle the floating-point diff and `pdiff`, we scale it by 10^6 (1_000_000) to convert it to an integer
@@ -146,13 +146,12 @@ impl Downstream {
         }
         let diff: u128 = scaled_difficulty as u128;
 
-        let diff = from_u128_to_uint256(diff);
-        let scale = from_u128_to_uint256(scale);
+        let diff = from_u128_to_u256(diff);
+        let scale = from_u128_to_u256(scale);
 
         let target = pdiff.mul(scale).div(diff);
-        let mut target = target.to_be_bytes();
+        let target: [u8; 32] = target.to_big_endian();
 
-        target.reverse(); // Convert to little-endian for SV1
         target
     }
 

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -92,7 +92,7 @@ pub struct Downstream {
     //extranonce1: Vec<u8>,
     //extranonce2_size: usize,
     /// Version rolling mask bits
-    version_rolling_mask: Option<HexU32Be>,
+    pub(super) version_rolling_mask: Option<HexU32Be>,
     /// Minimum version rolling mask bits size
     version_rolling_min_bit: Option<HexU32Be>,
     /// Sends a SV1 `mining.submit` message received from the Downstream role to the `Bridge` for

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -107,7 +107,6 @@ pub struct Downstream {
     pub last_call_to_update_hr: u128,
     pub(super) last_notify: Option<server_to_client::Notify<'static>>,
     pub(super) stats_sender: StatsSender,
-    pub connected_at: tokio::time::Instant, // Tracks connection time
 }
 
 impl Downstream {
@@ -189,7 +188,6 @@ impl Downstream {
             last_call_to_update_hr: 0,
             last_notify: last_notify.clone(),
             stats_sender,
-            connected_at: tokio::time::Instant::now(),
         }));
 
         if let Err(e) = start_receive_downstream(
@@ -364,7 +362,6 @@ impl Downstream {
             last_call_to_update_hr: 0,
             last_notify: None,
             stats_sender,
-            connected_at: tokio::time::Instant::now(),
         }
     }
 }

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -107,6 +107,7 @@ pub struct Downstream {
     pub last_call_to_update_hr: u128,
     pub(super) last_notify: Option<server_to_client::Notify<'static>>,
     pub(super) stats_sender: StatsSender,
+    pub connected_at: tokio::time::Instant, // Tracks connection time
 }
 
 impl Downstream {
@@ -188,6 +189,7 @@ impl Downstream {
             last_call_to_update_hr: 0,
             last_notify: last_notify.clone(),
             stats_sender,
+            connected_at: tokio::time::Instant::now(),
         }));
 
         if let Err(e) = start_receive_downstream(
@@ -362,6 +364,7 @@ impl Downstream {
             last_call_to_update_hr: 0,
             last_notify: None,
             stats_sender,
+            connected_at: tokio::time::Instant::now(),
         }
     }
 }

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -124,6 +124,8 @@ async fn start_update(
     connection_id: u32,
 ) -> Result<(), Error<'static>> {
     let handle = task::spawn(async move {
+        // Prevent difficulty adjustments until after crate::ARGS.delay elapses
+        tokio::time::sleep(std::time::Duration::from_secs(crate::ARGS.delay)).await;
         loop {
             let share_count = crate::translator::utils::get_share_count(connection_id);
             let sleep_duration = if share_count >= crate::SHARE_PER_MIN * 3.0

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -7,9 +7,16 @@ use roles_logic_sv2::utils::Mutex;
 use std::sync::Arc;
 use sv1_api::json_rpc;
 use sv1_api::server_to_client;
+use sv1_api::utils::HexU32Be;
 use tokio::sync::broadcast;
 use tokio::task;
 use tracing::{error, warn};
+
+fn apply_mask(mask: Option<HexU32Be>, message: &mut server_to_client::Notify<'static>) {
+    if let Some(mask) = mask {
+        message.version = HexU32Be(message.version.0 & !mask.0);
+    }
+}
 
 pub async fn start_notify(
     task_manager: Arc<Mutex<TaskManager>>,
@@ -31,6 +38,9 @@ pub async fn start_notify(
             let timeout_timer = std::time::Instant::now();
             let mut first_sent = false;
             loop {
+                let mask = downstream
+                    .safe_lock(|d| d.version_rolling_mask.clone())
+                    .unwrap();
                 let is_a = match downstream.safe_lock(|d| !d.authorized_names.is_empty()) {
                     Ok(is_a) => is_a,
                     Err(e) => {
@@ -44,7 +54,7 @@ pub async fn start_notify(
                         error!("Failed to initailize difficulty managemant {e}")
                     };
 
-                    let sv1_mining_notify_msg = match last_notify.clone() {
+                    let mut sv1_mining_notify_msg = match last_notify.clone() {
                         Some(sv1_mining_notify_msg) => sv1_mining_notify_msg,
                         None => {
                             error!("sv1_mining_notify_msg is None");
@@ -54,6 +64,7 @@ pub async fn start_notify(
                             break;
                         }
                     };
+                    apply_mask(mask, &mut sv1_mining_notify_msg);
                     let message: json_rpc::Message = sv1_mining_notify_msg.into();
                     Downstream::send_message_downstream(downstream.clone(), message).await;
                     if downstream
@@ -76,7 +87,7 @@ pub async fn start_notify(
                         break;
                     };
 
-                    while let Ok(sv1_mining_notify_msg) = rx_sv1_notify.recv().await {
+                    while let Ok(mut sv1_mining_notify_msg) = rx_sv1_notify.recv().await {
                         if downstream
                             .safe_lock(|d| d.last_notify = Some(sv1_mining_notify_msg.clone()))
                             .is_err()
@@ -88,6 +99,7 @@ pub async fn start_notify(
                             break;
                         }
 
+                        apply_mask(mask.clone(), &mut sv1_mining_notify_msg);
                         let message: json_rpc::Message = sv1_mining_notify_msg.into();
                         Downstream::send_message_downstream(downstream.clone(), message).await;
                     }

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -8,7 +8,10 @@ use roles_logic_sv2::{
     parsers::Mining,
     utils::{GroupId, Mutex},
 };
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
 use sv1_api::{client_to_server::Submit, server_to_client, utils::HexU32Be};
 use tokio::sync::broadcast;
 
@@ -23,9 +26,13 @@ use crate::{
     proxy_state::{ProxyState, TranslatorState, UpstreamType},
     shared::utils::AbortOnDrop,
 };
+use lazy_static::lazy_static;
 use roles_logic_sv2::{channel_logic::channel_factory::OnNewShare, Error as RolesLogicError};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
+lazy_static! {
+    static ref SUBMIT_FAIL_COUNTER: AtomicU32 = AtomicU32::new(0);
+}
 /// Bridge between the SV2 `Upstream` and SV1 `Downstream` responsible for the following messaging
 /// translation:
 /// 1. SV1 `mining.submit` -> SV2 `SubmitSharesExtended`
@@ -253,29 +260,41 @@ impl Bridge {
         let res = self_
             .safe_lock(|s| {
                 s.channel_factory.set_target(&mut upstream_target);
-                let sv2_submit = match s.translate_submit(
+                 match s.translate_submit(
                     share.channel_id,
                     share.share,
                     share.version_rolling_mask,
                 ) {
-                    Ok(submit_shares_extended) => submit_shares_extended,
+                    Ok(submit_shares_extended) => {
+                        SUBMIT_FAIL_COUNTER.store(0, Ordering::Relaxed); // Reset on success
+                        let on_new_share = s.channel_factory.on_submit_shares_extended(submit_shares_extended);
+                    Ok(Some(on_new_share))},
                     Err(e) => {
-                        error!("Failed to Translates SV1 mining.submit message to SV2 SubmitSharesExtended message");
-                        return Err(e); // Error will be handled by the caller
+                        // Increment counter and get the new count
+                        let count = SUBMIT_FAIL_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+                        if count >= 10 {
+                            error!("Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message after 10 attempts");
+                            Err(e)
+                        } else {
+                            warn!(
+                                "Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message, attempt {}",
+                                count
+                            );
+                           Ok(None)
+                        }
                     }
-                };
-                Ok(s.channel_factory.on_submit_shares_extended(sv2_submit))
+                }
             })
             .map_err(|_| Error::BridgeMutexPoisoned)?;
 
         match res {
-            Ok(Ok(OnNewShare::SendErrorDownstream(e))) => {
+            Ok(Some(Ok(OnNewShare::SendErrorDownstream(e)))) => {
                 let error_code = std::str::from_utf8(&e.error_code.to_vec()[..])
                     .unwrap_or("unparsable error code")
                     .to_string();
                 error!("Submit share error {}", error_code);
             }
-            Ok(Ok(OnNewShare::SendSubmitShareUpstream((share, _)))) => {
+            Ok(Some(Ok(OnNewShare::SendSubmitShareUpstream((share, _))))) => {
                 info!("SHARE MEETS UPSTREAM TARGET channel id: {}", channel_id);
                 match share {
                     Share::Extended(share) => {
@@ -289,15 +308,19 @@ impl Bridge {
                 }
             }
             // We are in an extended channel this variant is group channle only
-            Ok(Ok(OnNewShare::RelaySubmitShareUpstream)) => unreachable!(),
-            Ok(Ok(OnNewShare::ShareMeetDownstreamTarget)) => {
+            Ok(Some(Ok(OnNewShare::RelaySubmitShareUpstream))) => unreachable!(),
+            Ok(Some(Ok(OnNewShare::ShareMeetDownstreamTarget))) => {
                 info!("SHARE MEETS DOWNSTREAM TARGET channel id {}", channel_id);
             }
             // Proxy do not have JD capabilities
-            Ok(Ok(OnNewShare::ShareMeetBitcoinTarget(..))) => unreachable!(),
-            Ok(Err(e)) => {
+            Ok(Some(Ok(OnNewShare::ShareMeetBitcoinTarget(..)))) => unreachable!(),
+            Ok(Some(Err(e))) => {
                 error!("{}", e);
                 return Err(Error::RolesSv2Logic(e));
+            }
+            Ok(None) => {
+                // Translation failed with count < 10; warning already logged
+                return Ok(());
             }
             Err(e) => {
                 error!("{}", e);

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -578,8 +578,6 @@ mod test {
     use super::*;
     use tokio::sync::mpsc;
 
-    use bitcoin::util::psbt::serialize::Serialize;
-
     pub mod test_utils {
         use super::*;
 
@@ -633,22 +631,22 @@ mod test {
                 ])
                 .unwrap();
                 let p_out = bitcoin::OutPoint {
-                    txid: bitcoin::Txid::from_hash(out_id),
+                    txid: bitcoin::Txid::from_raw_hash(out_id),
                     vout: 0xffff_ffff,
                 };
                 let in_ = bitcoin::TxIn {
                     previous_output: p_out,
                     script_sig: vec![89_u8; 16].into(),
                     sequence: bitcoin::Sequence(0),
-                    witness: Witness::from_vec(vec![]).into(),
+                    witness: Witness::new(),
                 };
                 let tx = bitcoin::Transaction {
-                    version: 1,
-                    lock_time: bitcoin::PackedLockTime(0),
+                    version: bitcoin::transaction::Version(1),
+                    lock_time: bitcoin::locktime::absolute::LockTime::from_time(0).unwrap(),
                     input: vec![in_],
                     output: vec![],
                 };
-                let tx = tx.serialize();
+                let tx = bitcoin::consensus::serialize(&tx);
                 let _down = bridge
                     .channel_factory
                     .add_standard_channel(0, 10_000_000_000.0, true, 1)


### PR DESCRIPTION
This PR adds a configurable `delay` before starting difficulty adjustments for each miner. The delay is set via a command-line arg, to accommodate slow-starting miners that may take some time before hashing. 

### Changes
- Modified `init_difficulty_management` to sleep for the duration of `delay`
