### PR TITLE
Handle SetNewPrevHash Mismatch, Config File Support, and Multiple Pool Addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "demand-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-recursion",
  "axum",
@@ -641,6 +641,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1654,6 +1655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,10 +1895,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1897,9 +1922,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand-cli"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [dependencies]
@@ -23,6 +23,7 @@ axum = {version = "0.8.1"}
 serde = { version = "1.0.219", features = ["derive"] }  
 sysinfo = {version = "0.33.1"}
 primitive-types = { version = "0.13.1" }
+toml ={ version = "0.8.22" }
 #roles_logic_sv2 = "1.2.1"
 #sv1_api = "1.0.1"
 #demand-sv2-connection = "0.0.3"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+token="NhCKk9trVihII3TielJh"
+pool_addresses=["3.74.36.119:2000", "3.74.36.119:2000"]

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,9 @@
-token="NhCKk9trVihII3TielJh"
-pool_addresses=["3.74.36.119:2000", "3.74.36.119:2000"]
+token="xxxxxxxxxx"
+pool_addresses=["18.193.252.132:2000", "3.74.36.119:2000"]
+tp_address = "127.0.0.1:8442"
+interval = 120_000
+delay = 540
+downstream_hashrate = "100T"
+loglevel = "info"
+nc_loglevel = "off"
+test = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,274 @@
+use clap::Parser;
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use std::{
+    net::{SocketAddr, ToSocketAddrs},
+    path::PathBuf,
+};
+use tracing::error;
+
+use crate::HashUnit;
+lazy_static! {
+    pub static ref CONFIG: Configuration = Configuration::load_config();
+}
+#[derive(Parser)]
+struct Args {
+    #[clap(long)]
+    test: bool,
+    #[clap(long = "d", short = 'd', value_parser = parse_hashrate)]
+    downstream_hashrate: Option<f32>,
+    #[clap(long = "loglevel", short = 'l')]
+    loglevel: Option<String>,
+    #[clap(long = "nc", short = 'n')]
+    noise_connection_log: Option<String>,
+    #[clap(long = "delay")]
+    delay: Option<u64>,
+    #[clap(long = "interval", short = 'i')]
+    adjustment_interval: Option<u64>,
+    #[clap(long = "pool", short = 'p', value_delimiter = ',')]
+    pool_addresses: Option<Vec<String>>,
+    #[clap(long)]
+    token: Option<String>,
+    #[clap(long)]
+    tp_address: Option<String>,
+    #[clap(long)]
+    listening_addr: Option<String>,
+    #[clap(long = "config", short = 'c')]
+    config_file: Option<PathBuf>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ConfigFile {
+    token: Option<String>,
+    tp_address: Option<String>,
+    pool_addresses: Option<Vec<String>>,
+    interval: Option<u64>,
+    delay: Option<u64>,
+    downstream_hashrate: Option<f32>,
+    loglevel: Option<String>,
+    nc_loglevel: Option<String>,
+    test: Option<bool>,
+    listening_addr: Option<String>,
+}
+
+pub struct Configuration {
+    token: Option<String>,
+    tp_address: Option<String>,
+    pool_addresses: Option<Vec<SocketAddr>>,
+    interval: u64,
+    delay: u64,
+    downstream_hashrate: Option<f32>,
+    loglevel: String,
+    nc_loglevel: String,
+    test: bool,
+    listening_addr: Option<String>,
+}
+impl Configuration {
+    pub fn token() -> Option<String> {
+        CONFIG.token.clone()
+    }
+
+    pub fn tp_address() -> Option<String> {
+        CONFIG.tp_address.clone()
+    }
+
+    pub fn pool_address() -> Option<Vec<SocketAddr>> {
+        CONFIG.pool_addresses.clone()
+    }
+
+    pub fn adjustment_interval() -> u64 {
+        CONFIG.interval
+    }
+
+    pub fn delay() -> u64 {
+        CONFIG.delay
+    }
+
+    pub fn downstream_hashrate() -> Option<f32> {
+        CONFIG.downstream_hashrate
+    }
+
+    pub fn downstream_listening_addr() -> Option<String> {
+        CONFIG.listening_addr.clone()
+    }
+
+    pub fn loglevel() -> &'static str {
+        match CONFIG.loglevel.to_lowercase().as_str() {
+            "trace" | "debug" | "info" | "warn" | "error" => &CONFIG.loglevel,
+            _ => {
+                error!(
+                    "Invalid log level '{}'. Defaulting to 'info'.",
+                    CONFIG.loglevel
+                );
+                "info"
+            }
+        }
+    }
+
+    pub fn nc_loglevel() -> &'static str {
+        match CONFIG.nc_loglevel.as_str() {
+            "trace" | "debug" | "info" | "warn" | "error" => &CONFIG.nc_loglevel,
+            _ => {
+                error!(
+                    "Invalid log level for noise_connection '{}' Defaulting to 'off'.",
+                    &CONFIG.nc_loglevel
+                );
+                "off"
+            }
+        }
+    }
+
+    pub fn test() -> bool {
+        CONFIG.test
+    }
+
+    // Loads config from CLI, file, or env vars with precedence: CLI > file > env.
+    fn load_config() -> Self {
+        let args = Args::parse();
+        let config_path: PathBuf = args.config_file.unwrap_or("config.toml".into());
+        let config: ConfigFile = std::fs::read_to_string(&config_path)
+            .ok()
+            .and_then(|content| toml::from_str(&content).ok())
+            .unwrap_or(ConfigFile {
+                token: None,
+                tp_address: None,
+                pool_addresses: None,
+                interval: None,
+                delay: None,
+                downstream_hashrate: None,
+                loglevel: None,
+                nc_loglevel: None,
+                test: None,
+                listening_addr: None,
+            });
+
+        let token = args
+            .token
+            .or(config.token)
+            .or_else(|| std::env::var("TOKEN").ok());
+
+        let tp_address = args
+            .tp_address
+            .or(config.tp_address)
+            .or_else(|| std::env::var("TP_ADDRESS").ok());
+
+        let pool_addresses: Option<Vec<SocketAddr>> = args
+            .pool_addresses
+            .map(|addresses| {
+                addresses
+                    .into_iter()
+                    .map(parse_address)
+                    .collect::<Vec<SocketAddr>>()
+            })
+            .or_else(|| {
+                config.pool_addresses.map(|addresses| {
+                    addresses
+                        .into_iter()
+                        .map(parse_address)
+                        .collect::<Vec<SocketAddr>>()
+                })
+            })
+            .or_else(|| {
+                std::env::var("POOL_ADDRESSES").ok().map(|s| {
+                    s.split(',')
+                        .map(|s| parse_address(s.trim().to_string()))
+                        .collect::<Vec<SocketAddr>>()
+                })
+            });
+
+        let interval = args
+            .adjustment_interval
+            .or(config.interval)
+            .or_else(|| std::env::var("INTERVAL").ok().and_then(|s| s.parse().ok()))
+            .unwrap_or(120000);
+
+        let delay = args
+            .delay
+            .or(config.delay)
+            .or_else(|| std::env::var("DELAY").ok().and_then(|s| s.parse().ok()))
+            .unwrap_or(0);
+
+        let downstream_hashrate = args
+            .downstream_hashrate
+            .or(config.downstream_hashrate)
+            .or_else(|| {
+                std::env::var("DOWNSTREAM_HASHRATE")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+            });
+
+        let listening_addr = args.listening_addr.or(config.listening_addr).or_else(|| {
+            std::env::var("DOWNSTREAM_HASHRATE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        });
+
+        let loglevel = args
+            .loglevel
+            .or(config.loglevel)
+            .or_else(|| std::env::var("LOGLEVEL").ok())
+            .unwrap_or("info".to_string());
+
+        let nc_loglevel = args
+            .noise_connection_log
+            .or(config.nc_loglevel)
+            .or_else(|| std::env::var("NC_LOGLEVEL").ok())
+            .unwrap_or("off".to_string());
+
+        let test = args.test || config.test.unwrap_or(false) || std::env::var("TEST").is_ok();
+
+        Configuration {
+            token,
+            tp_address,
+            pool_addresses,
+            interval,
+            delay,
+            downstream_hashrate,
+            loglevel,
+            nc_loglevel,
+            test,
+            listening_addr,
+        }
+    }
+}
+
+/// Parses a hashrate string (e.g., "10T", "2.5P", "500E") into an f32 value in h/s.
+fn parse_hashrate(hashrate_str: &str) -> Result<f32, String> {
+    let hashrate_str = hashrate_str.trim();
+    if hashrate_str.is_empty() {
+        return Err("Hashrate cannot be empty. Expected format: '<number><unit>' (e.g., '10T', '2.5P', '5E'".to_string());
+    }
+
+    let unit = hashrate_str.chars().last().unwrap_or(' ').to_string();
+    let num = &hashrate_str[..hashrate_str.len().saturating_sub(1)];
+
+    let num: f32 = num.parse().map_err(|_| {
+        format!(
+            "Invalid number '{}'. Expected format: '<number><unit>' (e.g., '10T', '2.5P', '5E')",
+            num
+        )
+    })?;
+
+    let multiplier = HashUnit::from_str(&unit)
+        .map(|unit| unit.multiplier())
+        .ok_or_else(|| format!(
+            "Invalid unit '{}'. Expected 'T' (Terahash), 'P' (Petahash), or 'E' (Exahash). Example: '10T', '2.5P', '5E'",
+            unit
+        ))?;
+
+    let hashrate = num * multiplier;
+
+    if hashrate.is_infinite() || hashrate.is_nan() {
+        return Err("Hashrate too large or invalid".to_string());
+    }
+
+    Ok(hashrate)
+}
+
+fn parse_address(addr: String) -> SocketAddr {
+    addr.to_socket_addrs()
+        .map_err(|e| error!("Invalid socket address: {}", e))
+        .expect("Failed to parse socket address")
+        .next()
+        .expect("No socket address resolved")
+}

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -57,7 +57,7 @@ pub struct JobDeclarator {
     min_extranonce_size: u16,
     // (Sent DeclareMiningJob, is future, template id, merkle path)
     last_declare_mining_jobs_sent: HashMap<u32, Option<LastDeclareJob>>,
-    last_set_new_prev_hash: Option<SetNewPrevHash<'static>>,
+    pub last_set_new_prev_hash: Option<SetNewPrevHash<'static>>,
     set_new_prev_hash_counter: u8,
     #[allow(clippy::type_complexity)]
     future_jobs: HashMap<

--- a/src/jd_client/job_declarator/setup_connection.rs
+++ b/src/jd_client/job_declarator/setup_connection.rs
@@ -10,6 +10,8 @@ use roles_logic_sv2::{
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tokio::sync::mpsc::{Receiver as TReceiver, Sender as TSender};
 use tracing::error;
+
+use crate::config::Configuration;
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;
@@ -26,7 +28,7 @@ impl SetupConnectionHandler {
         let vendor = String::new().try_into().expect("Internal error: this operation can not fail because empty string can always be converted into Inner");
         let hardware_version = String::new().try_into().expect("Internal error: this operation can not fail because empty string can always be converted into Inner");
         let firmware = String::new().try_into().expect("Internal error: this operation can not fail because empty string can always be converted into Inner");
-        let token = std::env::var("TOKEN").expect("Checked at initialization");
+        let token = Configuration::token().expect("Checked at initialization");
         let device_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
         let device_id = format!("{}::POOLED::{}", device_id, token)
             .to_string()

--- a/src/jd_client/job_declarator/setup_connection.rs
+++ b/src/jd_client/job_declarator/setup_connection.rs
@@ -1,3 +1,4 @@
+use crate::config::Configuration;
 use codec_sv2::{StandardEitherFrame, StandardSv2Frame};
 use rand::distributions::{Alphanumeric, DistString};
 use roles_logic_sv2::{
@@ -11,7 +12,6 @@ use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tokio::sync::mpsc::{Receiver as TReceiver, Sender as TSender};
 use tracing::error;
 
-use crate::config::Configuration;
 pub type Message = PoolMessages<'static>;
 pub type StdFrame = StandardSv2Frame<Message>;
 pub type EitherFrame = StandardEitherFrame<Message>;

--- a/src/jd_client/mining_downstream/mod.rs
+++ b/src/jd_client/mining_downstream/mod.rs
@@ -47,7 +47,7 @@ pub struct DownstreamMiningNode {
     miner_coinbase_output: Vec<TxOut>,
     // used to retreive the job id of the share that we send upstream
     last_template_id: u64,
-    jd: Option<Arc<Mutex<JobDeclarator>>>,
+    pub jd: Option<Arc<Mutex<JobDeclarator>>>,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/src/jd_client/mining_upstream/upstream.rs
+++ b/src/jd_client/mining_upstream/upstream.rs
@@ -565,7 +565,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
         if let Some(downstream) = &self.downstream {
             if let Ok(Some(jd)) = downstream.safe_lock(|d| d.jd.clone()) {
-                // Compare pool's prev_hash with TP's prev_hash
+                // Compare pool's prev_hash with JD's prev_hash
                 let is_mismatch = jd
                     .safe_lock(|jd| jd.last_set_new_prev_hash.clone())
                     .map(|tp| match tp {

--- a/src/jd_client/mining_upstream/upstream.rs
+++ b/src/jd_client/mining_upstream/upstream.rs
@@ -561,9 +561,47 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
     /// role.
     fn handle_set_new_prev_hash(
         &mut self,
-        _: roles_logic_sv2::mining_sv2::SetNewPrevHash,
+        m: roles_logic_sv2::mining_sv2::SetNewPrevHash,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
-        warn!("SNPH received from upstream, proxy ignore it, and use the one declared by JOB DECLARATOR");
+        if let Some(downstream) = &self.downstream {
+            if let Ok(Some(jd)) = downstream.safe_lock(|d| d.jd.clone()) {
+                // Compare pool's prev_hash with TP's prev_hash
+                let is_mismatch = jd
+                    .safe_lock(|jd| jd.last_set_new_prev_hash.clone())
+                    .map(|tp| match tp {
+                        Some(tp) => tp.prev_hash != m.prev_hash,
+                        None => true, // Treat as mismatch if jd last_set_new_prev_hash is None
+                    })
+                    .map_err(|_| RolesLogicError::PoisonLock("JD mutex corrupt".to_string()))?;
+
+                if is_mismatch {
+                    info!("Pool's SetNewPrevHash differs from TP or TP SetNewPrevHash not received; starting 10s timer");
+                    let jd_clone = jd.clone();
+                    let pool_prev_hash = m.prev_hash.clone().into_static();
+                    tokio::task::spawn(async move {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                        // After 10 seconds, check if Jd's prev_hash matches the pool's
+                        let current_jd_prev_hash = jd_clone
+                            .safe_lock(|j| j.last_set_new_prev_hash.clone())
+                            .map_err(|_| error!("Job declaration Mutex corrupt"))
+                            .unwrap_or(None);
+
+                        let still_mismatch = current_jd_prev_hash
+                            .map(|tp| tp.prev_hash != pool_prev_hash)
+                            .unwrap_or(true); // Mismatch if current_jd_prev_hash is still None
+
+                        if still_mismatch {
+                            error!("Stopping job declaration due to persistent prev_hash mismatch");
+                            if crate::TP_ADDRESS.safe_lock(|tp| *tp = None).is_err() {
+                                error!("TP_ADDRESS mutex corrupt");
+                            };
+                            ProxyState::update_inconsistency(Some(1));
+                        }
+                    });
+                }
+            }
+        }
+        warn!("SNPH received from upstream, proxy ignores it, and uses the one declared by JOB DECLARATOR");
         Ok(SendTo::None(None))
     }
 

--- a/src/jd_client/mod.rs
+++ b/src/jd_client/mod.rs
@@ -113,10 +113,10 @@ async fn initialize_jd(
 
     let auth_pub_k: Secp256k1PublicKey = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
     let addresses = Configuration::pool_address().expect("Pool address is missing");
-    let address = addresses.first().expect("Pool address is missing");
+    let address = addresses.first().expect("Pool address is missing").clone();
 
     let (jd, jd_abortable) =
-        match JobDeclarator::new(*address, auth_pub_k.into_bytes(), upstream.clone(), true).await {
+        match JobDeclarator::new(address, auth_pub_k.into_bytes(), upstream.clone(), true).await {
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to intialize Jd: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
-mod config;
+
 use crate::shared::utils::AbortOnDrop;
 use config::Configuration;
 use key_utils::Secp256k1PublicKey;
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::channel;
 use tracing::{error, info, warn};
 mod api;
 
+mod config;
 mod ingress;
 pub mod jd_client;
 mod minin_pool_connection;

--- a/src/minin_pool_connection/mod.rs
+++ b/src/minin_pool_connection/mod.rs
@@ -18,7 +18,9 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{error, info};
 
-use crate::{proxy_state::ProxyState, shared::utils::AbortOnDrop, PoolState};
+use crate::{
+    config::Configuration, proxy_state::ProxyState, shared::utils::AbortOnDrop, PoolState,
+};
 use task_manager::TaskManager;
 
 pub type Message = PoolExtMessages<'static>;
@@ -219,7 +221,7 @@ pub fn get_mining_setup_connection_msg(work_selection: bool) -> SetupConnection<
         false => 0b0000_0000_0000_0000_0000_0000_0000_0100,
         true => 0b0000_0000_0000_0000_0000_0000_0000_0110,
     };
-    let token = std::env::var("TOKEN").expect("Checked at initialization");
+    let token = Configuration::token().expect("Checked at initialization");
     let device_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
     let device_id = format!("{}::POOLED::{}", device_id, token)
         .to_string()

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -29,7 +29,7 @@ impl Downstream {
         let (message, _) = diff_to_sv1_message(diff as f64)?;
         Downstream::send_message_downstream(self_.clone(), message.clone()).await;
 
-        let total_delay = Duration::from_secs(crate::ARGS.delay);
+        let total_delay = Duration::from_secs(crate::Configuration::delay());
         let repeat_interval = Duration::from_secs(30);
 
         let self_clone = self_.clone();

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -148,17 +148,17 @@ async fn start_update(
     connection_id: u32,
 ) -> Result<(), Error<'static>> {
     let handle = task::spawn(async move {
-        // Prevent difficulty adjustments until after crate::ARGS.delay elapses
-        tokio::time::sleep(std::time::Duration::from_secs(crate::ARGS.delay)).await;
+        // Prevent difficulty adjustments until after delay elapses
+        tokio::time::sleep(std::time::Duration::from_secs(crate::Configuration::delay())).await;
         loop {
             let share_count = crate::translator::utils::get_share_count(connection_id);
             let sleep_duration = if share_count >= crate::SHARE_PER_MIN * 3.0
                 || share_count <= crate::SHARE_PER_MIN / 3.0
             {
                 // TODO: this should only apply when after the first share has been received
-                std::time::Duration::from_millis(crate::ARGS.adjustment_interval)
+                std::time::Duration::from_millis(crate::Configuration::adjustment_interval())
             } else {
-                std::time::Duration::from_millis(crate::ARGS.adjustment_interval)
+                std::time::Duration::from_millis(crate::Configuration::adjustment_interval())
             };
 
             tokio::time::sleep(sleep_duration).await;


### PR DESCRIPTION
#### Changes
- Handles cases where the `SetNewPrevHash` from the pool either arrives before the TP’s or differs from it. If the TP’s `SetNewPrevHash`  is missing or mismatched after a 10-second wait, the proxy falls back to non-jd mode.
- Adds support for loading env variables from a` .toml` config file.
- Support multiple pool addresses, so the proxy can select and connect to the one with the least latency.