### PR TITLE
Fix/expected share reduction

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.87.0"
           components: rustfmt, clippy
 
       - name: Run cargo fmt

--- a/src/ingress/sv1_ingress.rs
+++ b/src/ingress/sv1_ingress.rs
@@ -1,4 +1,7 @@
-use std::{net::{IpAddr, SocketAddr}, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 use crate::{
     config::Configuration,
@@ -96,14 +99,12 @@ impl Downstream {
                 if Configuration::sv1_ingress_log() {
                     info!("Sending msg to upstream: {}", message);
                 }
-                if ! is_subscribed {
-                    if message.contains("mining.subscribe") {
-                        is_subscribed = true;
-                        if message.contains("LUXminer") {
-                            firmware.safe_lock(|f| *f = Firmware::Luxor).unwrap();
-                        } else {
-                            firmware.safe_lock(|f| *f = Firmware::Other).unwrap();
-                        }
+                if !is_subscribed && message.contains("mining.subscribe") {
+                    is_subscribed = true;
+                    if message.contains("LUXminer") {
+                        firmware.safe_lock(|f| *f = Firmware::Luxor).unwrap();
+                    } else {
+                        firmware.safe_lock(|f| *f = Firmware::Other).unwrap();
                     }
                 }
                 if send.send(message).await.is_err() {
@@ -158,7 +159,7 @@ impl Downstream {
     }
 }
 
-#[derive(Debug,Clone,Copy)]
+#[derive(Debug, Clone, Copy)]
 enum Firmware {
     Luxor,
     Other,

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -354,6 +354,7 @@ impl Downstream {
         difficulty_mgmt: DownstreamDifficultyConfig,
         upstream_difficulty_config: Arc<Mutex<UpstreamDifficultyConfig>>,
         stats_sender: StatsSender,
+        first_job: Notify<'static>,
     ) -> Self {
         Downstream {
             connection_id,
@@ -367,7 +368,7 @@ impl Downstream {
             difficulty_mgmt,
             upstream_difficulty_config,
             last_call_to_update_hr: 0,
-            first_job: Notify,
+            first_job,
             stats_sender,
             recent_jobs: RecentJobs::new(),
         }
@@ -494,11 +495,11 @@ impl IsServer<'static> for Downstream {
                             "Share for Job {} and difficulty {} is accepted",
                             request.job_id, met_difficulty
                         );
-                        return true;
+                        true
                     } else {
                         error!("Share rejected: Invalid share");
                         self.stats_sender.update_rejected_shares(self.connection_id);
-                        return false;
+                        false
                     }
                 } else {
                     error!(
@@ -506,7 +507,7 @@ impl IsServer<'static> for Downstream {
                         request.job_id
                     );
                     self.stats_sender.update_rejected_shares(self.connection_id);
-                    return false;
+                    false
                 }
             }
             Ok(false) => {

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -89,9 +89,7 @@ pub async fn start_notify(
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
-            if let Err(e) =
-                start_update(task_manager, downstream.clone(), connection_id).await
-            {
+            if let Err(e) = start_update(task_manager, downstream.clone(), connection_id).await {
                 warn!("Translator impossible to start update task: {e}");
             } else if authorized_in_time {
                 // Get the mask after initialization since is set by configure message


### PR DESCRIPTION
The expected hash rate is ~30% lower than the `-d` value due to aggressive difficulty rounding. This change:
- Adjusts the calculation so that the resulting initial hash rate better matches the miner's `-d` value.
    - Fixes https://github.com/demand-open-source/demand-cli/issues/93
- Fixes `cargo fmt`, `clippy` and `test` issues introduced by the previous pr merges