### PR TITLE
Fix share submit when exceed upstream capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "demand-cli"
-version = "0.1.14"
+version = "0.1.16"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 
 [dependencies]

--- a/src/ingress/sv1_ingress.rs
+++ b/src/ingress/sv1_ingress.rs
@@ -1,4 +1,7 @@
-use std::{net::{IpAddr, SocketAddr}, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 use crate::{
     config::Configuration,
@@ -96,7 +99,7 @@ impl Downstream {
                 if Configuration::sv1_ingress_log() {
                     info!("Sending msg to upstream: {}", message);
                 }
-                if ! is_subscribed {
+                if !is_subscribed {
                     if message.contains("mining.subscribe") {
                         is_subscribed = true;
                         if message.contains("LUXminer") {
@@ -158,7 +161,7 @@ impl Downstream {
     }
 }
 
-#[derive(Debug,Clone,Copy)]
+#[derive(Debug, Clone, Copy)]
 enum Firmware {
     Luxor,
     Other,

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -89,9 +89,7 @@ pub async fn start_notify(
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
-            if let Err(e) =
-                start_update(task_manager, downstream.clone(), connection_id).await
-            {
+            if let Err(e) = start_update(task_manager, downstream.clone(), connection_id).await {
                 warn!("Translator impossible to start update task: {e}");
             } else if authorized_in_time {
                 // Get the mask after initialization since is set by configure message


### PR DESCRIPTION
When downstream send a share but we exceed the upstream capacity (70 shares per minute) we are not going to send the share upstream. In that case before this commit we were sending downstream a share submission error even when the share is valid. We fix it and check the share target and send an error ONLY when the share is invalid.