### PR TITLE
Fix proxy restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "demand-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
d07b7f5e465b937a382ec2828a2b7a38fe8b3e93 introduced a way to kill specific tasks that handle downstream connections: so when a downstream will disconnect we make sure to kill all the tasks related with that downstream. In doing that it saved the task aborter in a field of the TaskManager making impossible to kill the tasks when the aborter was called somewhere else. Now we make sure that all the aborter live only under tasks that get killed when the main aborter of the TaskManager is called.