### PR TITLE
Handle connection failure if logging server is unavailable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,6 @@ async fn main() {
     let log_level = Configuration::loglevel();
     let noise_connection_log_level = Configuration::nc_loglevel();
 
-    let remote_layer = SendLogLayer::new();
     let console_layer =
         tracing_subscriber::fmt::layer().with_filter(tracing_subscriber::EnvFilter::new(format!(
             "{},demand_sv2_connection::noise_connection_tokio={}",
@@ -83,10 +82,16 @@ async fn main() {
     //Disable noise_connection error (for now) because:
     // 1. It produce logs that are not very user friendly and also bloat the logs
     // 2. The errors resulting from noise_connection are handled. E.g if unrecoverable error from noise connection occurs during Pool connection: We either retry connecting immediatley or we update Proxy state to Pool Down
-    tracing_subscriber::registry()
-        .with(console_layer)
-        .with(remote_layer)
-        .init();
+    if let Ok(remote_layer) = SendLogLayer::new().await {
+        tracing_subscriber::registry()
+            .with(console_layer)
+            .with(remote_layer)
+            .init();
+        info!("Remote logging server is enabled");
+    } else {
+        tracing_subscriber::registry().with(console_layer).init();
+        warn!("Remote logging server is disabled");
+    }
 
     Configuration::token().expect("TOKEN is not set");
 

--- a/src/monitor/shares.rs
+++ b/src/monitor/shares.rs
@@ -84,8 +84,14 @@ impl SharesMonitor {
             });
     }
 
-    pub async fn monitor(&self) {
-        let api = MonitorAPI::new(shares_server_endpoint());
+    pub async fn monitor(&self) -> Result<(), ()> {
+        let api = match MonitorAPI::new(shares_server_endpoint()).await {
+            Ok(api) => api,
+            Err(_) => {
+                error!("Shares monitor server is unreachable");
+                return Err(());
+            }
+        };
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         // First tick completes immediately
         interval.tick().await;

--- a/src/monitor/worker_activity.rs
+++ b/src/monitor/worker_activity.rs
@@ -22,7 +22,7 @@ impl WorkerActivity {
         }
     }
 
-    pub fn monitor_api(&self) -> MonitorAPI {
-        MonitorAPI::new(worker_activity_server_endpoint())
+    pub async fn monitor_api(&self) -> Result<MonitorAPI, ()> {
+        MonitorAPI::new(worker_activity_server_endpoint()).await
     }
 }


### PR DESCRIPTION
resolves #139

1) Don't connect log layer to remote logger at all if remote is not
   available
2) Check if server is available before logging worker activity


@Priceless-P do you mind testing how the logs would look like/the proxy behaves on a worker connect/disconnect activity?