### PR TITLE
Fix proxy extranonce range overflow after adding `additional_coinbase_data`

### DIFF
--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -123,7 +123,8 @@ impl Bridge {
                 if let Some(Mining::OpenExtendedMiningChannelSuccess(success)) = message.next() {
                     info!("New extended channel opened with id {}", success.channel_id);
                     let extranonce = success.extranonce_prefix.to_vec();
-                    let extranonce2_len = success.extranonce_size;
+                    let extranonce2_len =
+                        success.extranonce_size - success.extranonce_prefix.len() as u16;
                     self.target
                         .safe_lock(|t| *t = success.target.to_vec())
                         .map_err(|e| {

--- a/src/translator/upstream/upstream.rs
+++ b/src/translator/upstream/upstream.rs
@@ -273,9 +273,8 @@ impl Upstream {
                                         miner_extranonce2_size,
                                     );
                                     let range_0 = 0..prefix_len; // upstream extranonce1
-                                    let range_1 = prefix_len..prefix_len + tproxy_e1_len; // downstream extranonce1
-                                    let range_2 = prefix_len + tproxy_e1_len
-                                        ..prefix_len + m.extranonce_size as usize; // extranonce2
+                                    let range_1 = prefix_len..tproxy_e1_len; // downstream extranonce1
+                                    let range_2 = tproxy_e1_len..m.extranonce_size as usize; // extranonce2
                                     let extended = match ExtendedExtranonce::from_upstream_extranonce(
                                         extranonce_prefix.clone(), range_0.clone(), range_1.clone(), range_2.clone(),
                                     ).ok_or( Error::InvalidExtranonce(format!("Impossible to create a valid extended extranonce from {:?} {:?} {:?} {:?}",


### PR DESCRIPTION
Following [this change](https://github.com/demand-open-source/stratum/pull/16) , `m.extranonce_size` grew from 16 to 32 bytes. Proxy currently double-counted the prefix when calculating extranonce ranges, this now causes invalidExtranonceRange on channel creation.

This PR corrects the math by treating `tproxy_e1_len` as the actual end of `range_1`.

Currently we added the prefix twice:
```rs
let range_1 = prefix_len..prefix_len + tproxy_e1_len; // downstream extranonce1
let range_2 = prefix_len + tproxy_e1_len
    ..prefix_len + m.extranonce_size as usize;
```
With this change, we use `tproxy_e1_len` directly:

```rs
let range_1 = prefix_len..tproxy_e1_len // 16..27
let  range_2 = tproxy_e1_len..extranonce_size // 27..32
```
Also changed `extranonce2_len` in bridge.rs:
`let extranonce2_len = m.extranonce_size - prefix_len`

Now   it works but I’m not sure if it is working the way we want . 



Fixes https://github.com/demand-open-source/demand-pool/issues/264


Looking forward to your review @Fi3 @jbesraa 
