### PR TITLE
Make `SHARE_PER_MIN` configurable

### DIFF
--- a/src/jd_client/mining_upstream/upstream.rs
+++ b/src/jd_client/mining_upstream/upstream.rs
@@ -411,7 +411,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
             ids,
             extranonces,
             creator,
-            crate::SHARE_PER_MIN,
+            *crate::SHARE_PER_MIN,
             channel_kind,
             vec![],
             vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,6 @@ const MIN_EXTRANONCE_SIZE: u16 = 6;
 const MIN_EXTRANONCE2_SIZE: u16 = 5;
 const UPSTREAM_EXTRANONCE1_SIZE: usize = 15;
 const DEFAULT_SV1_HASHPOWER: f32 = 100_000_000_000_000.0;
-const SHARE_PER_MIN: f32 = 10.0;
 const CHANNEL_DIFF_UPDTATE_INTERVAL: u32 = 10;
 const MAX_LEN_DOWN_MSG: u32 = 10000;
 const MAIN_AUTH_PUB_KEY: &str = "9c44K6QVizyPWb9xfeqhckFRosxWwB3EfytGa4CfTdD526qb2QV";
@@ -67,6 +66,12 @@ lazy_static! {
     } else {
         MAIN_AUTH_PUB_KEY
     };
+}
+lazy_static! {
+    static ref SHARE_PER_MIN: f32 = std::env::var("SHARE_PER_MIN")
+        .unwrap_or("6.0".to_string())
+        .parse::<f32>()
+        .expect("SHARE_PER_MIN is not a valid number");
 }
 
 #[tokio::main]

--- a/src/translator/downstream/accept_connection.rs
+++ b/src/translator/downstream/accept_connection.rs
@@ -39,7 +39,7 @@ pub async fn start_accept_connection(
                     "Translator initial hash rate for ip {} is {} H/s",
                     addr, initial_hash_rate
                 );
-                let share_per_second = crate::SHARE_PER_MIN / 60.0;
+                let share_per_second = *crate::SHARE_PER_MIN / 60.0;
                 info!(
                     "Translator share per second for ip {} is {} shares/s",
                     addr, share_per_second
@@ -55,7 +55,7 @@ pub async fn start_accept_connection(
                 );
                 // Formula: expected_hash_rate = (shares_per_second) * initial_difficulty * 2^32, where shares_per_second = SHARE_PER_MIN / 60
                 let expected_hash_rate =
-                    (crate::SHARE_PER_MIN / 60.0) * initial_difficulty * 2f32.powf(32.0);
+                    (*crate::SHARE_PER_MIN / 60.0) * initial_difficulty * 2f32.powf(32.0);
                 info!(
                     "Translator expected hash rate for ip {} is {} H/s",
                     addr, expected_hash_rate

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -220,7 +220,7 @@ impl Downstream {
         let new_difficulty = (latest_difficulty + pid_output).max(initial_difficulty * 0.1);
         let nearest = nearest_power_of_10(new_difficulty);
         if nearest != initial_difficulty {
-            let mut pid: Pid<f32> = Pid::new(crate::SHARE_PER_MIN, nearest * 10.0);
+            let mut pid: Pid<f32> = Pid::new(*crate::SHARE_PER_MIN, nearest * 10.0);
             let pk = -nearest * 0.01;
             //let pi = initial_difficulty * 0.1;
             //let pd = initial_difficulty * 0.01;
@@ -231,7 +231,7 @@ impl Downstream {
             })?;
 
             let new_estimation =
-                Self::estimate_hash_rate_from_difficulty(nearest, crate::SHARE_PER_MIN);
+                Self::estimate_hash_rate_from_difficulty(nearest, *crate::SHARE_PER_MIN);
             Self::update_self_with_new_hash_rate(self_, new_estimation, nearest)?;
             Ok(Some(nearest))
         } else {
@@ -240,7 +240,7 @@ impl Downstream {
             let change = (new_difficulty - latest_difficulty).abs() / latest_difficulty;
             if change > threshold {
                 let new_estimation =
-                    Self::estimate_hash_rate_from_difficulty(new_difficulty, crate::SHARE_PER_MIN);
+                    Self::estimate_hash_rate_from_difficulty(new_difficulty, *crate::SHARE_PER_MIN);
                 Self::update_self_with_new_hash_rate(self_, new_estimation, new_difficulty)?;
                 Ok(Some(new_difficulty))
             } else {
@@ -412,7 +412,7 @@ mod test {
     }
 
     fn get_diff(hashrate: f32) -> f32 {
-        let share_per_second = crate::SHARE_PER_MIN / 60.0;
+        let share_per_second = *crate::SHARE_PER_MIN / 60.0;
         let initial_difficulty = hashrate / (share_per_second * 2f32.powf(32.0));
         crate::translator::downstream::diff_management::nearest_power_of_10(initial_difficulty)
     }

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -167,7 +167,7 @@ impl Downstream {
         // The positive D gain (0.05) dampens rapid changes, e.g., if share rate jumps from 8 to 12, D might
         // add a small positive adjustment to prevent overshooting.
 
-        let mut pid: Pid<f32> = Pid::new(crate::SHARE_PER_MIN, initial_difficulty * 10.0);
+        let mut pid: Pid<f32> = Pid::new(*crate::SHARE_PER_MIN, initial_difficulty * 10.0);
         let pk = -initial_difficulty * 0.01;
         //let pi = initial_difficulty * 0.1;
         //let pd = initial_difficulty * 0.01;

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -144,8 +144,8 @@ async fn start_update(
         tokio::time::sleep(std::time::Duration::from_secs(crate::Configuration::delay())).await;
         loop {
             let share_count = crate::translator::utils::get_share_count(connection_id);
-            let sleep_duration = if share_count >= crate::SHARE_PER_MIN * 3.0
-                || share_count <= crate::SHARE_PER_MIN / 3.0
+            let sleep_duration = if share_count >= *crate::SHARE_PER_MIN * 3.0
+                || share_count <= *crate::SHARE_PER_MIN / 3.0
             {
                 // TODO: this should only apply when after the first share has been received
                 std::time::Duration::from_millis(crate::Configuration::adjustment_interval())

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -99,7 +99,7 @@ impl Bridge {
                 ids,
                 extranonces,
                 None,
-                crate::SHARE_PER_MIN,
+                *crate::SHARE_PER_MIN,
                 ExtendedChannelKind::Proxy { upstream_target },
                 None,
                 channel_id,


### PR DESCRIPTION
Makes `SHARE_PER_MIN` a `lazy_static!` which defaults t `6.0` and allows for configuration via an environment variable.