### PR TITLE
Update cargo-release version for CI Rust toolchain compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: cargo install cargo-release --version '=0.25.19' --locked
 
       - name: Check if tag exists
         id: check_tag


### PR DESCRIPTION
This PR updates the cargo-release version to be compatible with the Rust toolchain used in our CI workflow, ensuring releases can be created without version conflicts.

Fixes #148 
