### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The default Template Provider port is **8336**.
 
 #### 4.1 Download DMND Stratum V2 Client
 You can download the latest release of DMND Stratum V2 Client from:
-https://github.com/dmnd-open-source/dmnd-client/releases/tag/v0.2.2
+https://github.com/dmnd-pool/dmnd-client/releases/tag/v0.2.2
 
 
 Assuming that `dmnd-client-linux` is the executable you are using, run:


### PR DESCRIPTION
Noticed while testing the instructions that due to repo renames this important onboarding link was broken. If you already have a fix, feel free to ignore and close this PR.