### PR TITLE
Made subscription id unique

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dashmap = {version = "6.1.0", features = ["inline"]}
 bitcoin = {version = "0.32.5", features = ["serde","rand"]}
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 tokio-util = { version = "*", features = ["codec"] }
+uuid = { version = "1", features = ["v4"] }
 nohash-hasher = "*"
 futures = "*"
 async-recursion = "1.0.0"

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -449,10 +449,7 @@ impl IsServer<'static> for Downstream {
             "mining.set_difficulty".to_string(),
             super::new_subscription_id(),
         );
-        let notify_sub = (
-            "mining.notify".to_string(),
-            "ae6812eb4cd7735a302a8a9dd95cf71f".to_string(),
-        );
+        let notify_sub = ("mining.notify".to_string(), super::new_subscription_id());
         self.user_agent.replace(request.agent_signature.clone());
         vec![set_difficulty_sub, notify_sub]
     }
@@ -800,18 +797,29 @@ impl<T, const N: usize> CircularBuffer<T, N> {
     }
 }
 
-//#[cfg(test)]
-//mod tests {
-//    use super::*;
-//
-//    #[test]
-//    fn gets_difficulty_from_target() {
-//        let target = vec![
-//            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 255, 127,
-//            0, 0, 0, 0, 0,
-//        ];
-//        let actual = Downstream::difficulty_from_target(target).unwrap();
-//        let expect = 512.0;
-//        assert_eq!(actual, expect);
-//    }
-//}
+#[cfg(test)]
+mod tests {
+    //    use super::*;
+    //
+    //    #[test]
+    //    fn gets_difficulty_from_target() {
+    //        let target = vec![
+    //            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 255, 127,
+    //            0, 0, 0, 0, 0,
+    //        ];
+    //        let actual = Downstream::difficulty_from_target(target).unwrap();
+    //        let expect = 512.0;
+    //        assert_eq!(actual, expect);
+    //    }
+
+    use crate::translator::downstream::new_subscription_id;
+    #[test]
+    fn id_is_32_hex_chars_and_unique() {
+        let a = new_subscription_id();
+        let b = new_subscription_id();
+        assert_eq!(a.len(), 32);
+        assert_eq!(b.len(), 32);
+        assert_ne!(a, b);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/src/translator/downstream/mod.rs
+++ b/src/translator/downstream/mod.rs
@@ -47,5 +47,5 @@ pub struct SetDownstreamTarget {
 }
 
 pub fn new_subscription_id() -> String {
-    "ae6812eb4cd7735a302a8a9dd95cf71f".into()
+    uuid::Uuid::new_v4().simple().to_string()
 }


### PR DESCRIPTION
Fixes #136 

Summary :-
- Added Uuid crate in cargo.toml 
- made `new_subscription_id()` function to generate id using uuid crate and removed hardcoded value from `mod.rs` and `downstream.rs`
- added test to check id created is unique and in proper format.

@Priceless-P