### PR TITLE
Fixed Rejected share count

### DIFF
--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -579,11 +579,10 @@ impl IsServer<'static> for Downstream {
                         request.job_id, met_difficulty
                     );
                     true
-                }
-                else {
-                error!("met_difficulty is not latest difficulty");
-                self.stats_sender.update_rejected_shares(self.connection_id);
-                false
+                } else {
+                    error!("met_difficulty is not latest difficulty");
+                    self.stats_sender.update_rejected_shares(self.connection_id);
+                    false
                 }
             } else {
                 let share = ShareInfo::new(


### PR DESCRIPTION
Fixes #152 

Summary :- 

the code logic earlier updated accepted share count even if met_difficulty was not latest difficulty, introduced a new variable to check if met_difficulty is not latest difficulty is there and update the rejected share count accordingly.

@jbesraa can you review it ?