### PR TITLE
Track share_monitor tasks by connection id

### DIFF
--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -264,7 +264,7 @@ impl Downstream {
         });
 
         // Register the task with the task manager so it can be aborted when needed
-        TaskManager::add_shares_monitor(task_manager, abortable.into())
+        TaskManager::add_shares_monitor(connection_id, task_manager, abortable.into())
             .await
             .map_err(|_| Error::TranslatorTaskManagerFailed)
     }

--- a/src/translator/downstream/task_manager.rs
+++ b/src/translator/downstream/task_manager.rs
@@ -146,12 +146,13 @@ impl TaskManager {
     }
 
     pub async fn add_shares_monitor(
+        connection_id: u32,
         self_: Arc<Mutex<Self>>,
         abortable: AbortOnDrop,
     ) -> Result<(), ()> {
         let send_task = self_.safe_lock(|s| s.send_task.clone()).unwrap();
         send_task
-            .send((None, Task::SharesMonitor(abortable)))
+            .send((Some(connection_id), Task::SharesMonitor(abortable)))
             .await
             .map_err(|_| ())
     }


### PR DESCRIPTION
TaskManager::add_share_monitor now takes a connection id.

This allows share_monitor tasks to be dropped automatically when the downstream connection is closed.

Fixes #177 