### PR TITLE
added a trigger to upload docker image on new tag in workflows (ecr.yml)

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -1,5 +1,8 @@
 name: Upload to ECR
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Added a `push.tags` trigger `(v*)` to the `upload_ecr` workflow so the docker image is automatically uploaded to ecr whenever a new version tag is pushed.
Fixes #189 