### PR TITLE
run first vardiff check right after delay

### DIFF
--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -142,6 +142,7 @@ async fn start_update(
     let handle = task::spawn(async move {
         // Prevent difficulty adjustments until after delay elapses
         tokio::time::sleep(std::time::Duration::from_secs(crate::Configuration::delay())).await;
+        // Run the first difficulty update right after delay, then continue on interval cadence.
         if let Err(e) = Downstream::try_update_difficulty_settings(&downstream).await {
             error!("{e}");
             return;


### PR DESCRIPTION
fixes #98

i have updated vardiff so the first adjustment now runs immediately after the configured delay and  kept the regular vardiff updates running on the configured interval after that.

@jbesraa @Fi3 