### PR TITLE
`handle_authorize` returns false when token is missing

### DIFF
--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -493,10 +493,8 @@ impl IsServer<'static> for Downstream {
                     }
                 });
             } else {
-                // TODO test that proxy do not fail when it happen but only close downstream
-                // connection
                 error!("Downstream is expected to carry a token");
-                ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+                return false;
             }
 
             let token = self.token.safe_lock(|t| t.clone()).unwrap_or_else(|e| {


### PR DESCRIPTION
fixes #200

log before the change
```
2026-03-16T09:54:00.168791Z  INFO dmnd_client::translator::proxy::bridge: New extended channel opened with id 1
2026-03-16T09:54:00.168909Z  INFO dmnd_client::translator::downstream::accept_connection: Translator opening connection for ip 127.0.0.1 with id 1
2026-03-16T09:54:00.169301Z  INFO dmnd_client::translator::downstream::downstream: Starting shares monitor for downstream: 1
2026-03-16T09:54:00.169335Z  INFO dmnd_client::translator::downstream::downstream: Down: Handling mining.subscribe: Subscribe { id: 1, agent_signature: "cpuminer/2.5.1", extranonce1: "None" }
2026-03-16T09:54:00.169497Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for auth
2026-03-16T09:54:00.169512Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for first job
2026-03-16T09:54:00.170537Z ERROR dmnd_client::translator::downstream::downstream: Downstream is expected to carry a token
2026-03-16T09:54:00.170560Z  INFO dmnd_client::proxy_state: Updating Downstream state to TranslatorDownstream
2026-03-16T09:54:00.264716Z ERROR dmnd_client: "[Downstream(Down([TranslatorDownstream]))]" is DOWN. Reinitializing proxy...
2026-03-16T09:54:00.265251Z ERROR dmnd_client::ingress::sv1_ingress: Upstream dropped trying to receive
2026-03-16T09:54:00.265456Z  WARN dmnd_client::ingress::sv1_ingress: Downstream dropped while trying to send message up
2026-03-16T09:54:00.277085Z  INFO dmnd_client::router: Selecting best Pool for connection
```



logs after the change
```
2026-03-16T09:54:38.524182Z  INFO dmnd_client::translator::proxy::bridge: New extended channel opened with id 1
2026-03-16T09:54:38.524246Z  INFO dmnd_client::translator::downstream::accept_connection: Translator opening connection for ip 127.0.0.1 with id 1
2026-03-16T09:54:38.524578Z  INFO dmnd_client::translator::downstream::downstream: Starting shares monitor for downstream: 1
2026-03-16T09:54:38.524616Z  INFO dmnd_client::translator::downstream::downstream: Down: Handling mining.subscribe: Subscribe { id: 1, agent_signature: "cpuminer/2.5.1", extranonce1: "None" }
2026-03-16T09:54:38.524951Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for auth
2026-03-16T09:54:38.524971Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for first job
2026-03-16T09:54:38.525486Z ERROR dmnd_client::translator::downstream::downstream: Downstream is expected to carry a token
2026-03-16T09:54:38.525715Z  WARN dmnd_client::ingress::sv1_ingress: Downstream dropped while trying to send message up
2026-03-16T09:54:38.525885Z  WARN dmnd_client::translator::downstream::receive_from_downstream: Downstream: Shutting down sv1 downstream reader 1
2026-03-16T09:54:38.525908Z  INFO dmnd_client::translator::downstream::diff_management: Removing downstream hashrate from channel upstream_diff: Mutex(Mutex { data: UpstreamDifficultyConfig { channel_diff_update_interval: 10, channel_nominal_hashrate: 10000000.0 }, poisoned: false, .. }), downstream_diff: 10000000.0
2026-03-16T09:54:39.527406Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for auth
2026-03-16T09:54:39.527518Z  WARN dmnd_client::translator::downstream::notify: Downstream 1: waiting for first job
2026-03-16T09:54:40.226508Z  INFO dmnd_client::translator::downstream::task_manager: Aborted all tasks for downstream connection ID 1
2026-03-16T09:54:40.226786Z ERROR dmnd_client::ingress::sv1_ingress: Upstream dropped trying to receive
2026-03-16T09:54:40.227888Z  INFO roles_logic_sv2::handlers::mining: Received new extended mining job for channel id: 13352 with job id: 19602 is_future: false
2026-03-16T09:54:40.228005Z  INFO dmnd_client::translator::upstream::upstream: Parsing incoming NewExtendedMiningJob message from Pool for Channel Id: 13352
2026-03-16T09:54:40.228510Z  INFO dmnd_client::translator::proxy::next_mining_notify: NextMiningNotify created for channel id: 13352, Job id: "19602", PrevHash: 0000000000000000000099aa7855ccf7a24519dc86c7f122fc28694c5b6ca35b version: HexU32Be(536870912), bits: HexU32Be(386003148), time: HexU32Be(1773654529), clean_jobs: true
2026-03-16T09:54:40.573551Z  INFO roles_logic_sv2::handlers::mining: Received SetTarget for channel id: 13352
```