### PR TITLE
ci: trigger ECR image upload on version tag

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -1,5 +1,8 @@
 name: Upload to ECR
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
When a new version tag (e.g. `v1.0.0`) is pushed, the `Upload to ECR` workflow
now triggers automatically via a `push.tags` event in addition to `workflow_dispatch`.

Closes #189