### PR TITLE
Allow the proxy to be initialized as a library

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install capnproto
-        run: sudo apt-get update -qq && sudo apt-get install -y capnproto
+        run: sudo apt-get update -qq && sudo apt-get install -y capnproto libcapnp-dev
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,9 @@ jobs:
           toolchain: "1.88.0"
           components: rustfmt, clippy
 
+      - name: Install capnproto
+        run: sudo apt-get update -qq && sudo apt-get install -y capnproto
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "dmnd-client"
 path = "src/main.rs"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["jemallocator"]
+
 [dependencies]
 dashmap = {version = "6.1.0", features = ["inline"]}
 bitcoin = {version = "0.32.5", features = ["serde","rand"]}
@@ -72,6 +76,8 @@ sv1_api = { git = "https://github.com/demand-open-source/stratum",subdirectory =
 [dev-dependencies]
 rand = "0.8.5"
 sha2 = "0.10.8"
+integration_tests_sv2 = { git = "https://github.com/stratum-mining/sv2-apps.git", branch = "main" }
+stratum-apps = { git = "https://github.com/stratum-mining/sv2-apps.git", branch = "main" }
 
 [profile.release]
 strip = true
@@ -82,4 +88,4 @@ panic = 'abort'
 panic = 'abort'
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-jemallocator = "*"
+jemallocator = { version = "*", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,10 +175,42 @@ impl Configuration {
             .expect("Configuration already initialized");
     }
 
+    #[cfg(test)]
+    fn default_for_tests() -> Self {
+        Self::new(
+            Some("test_token".to_string()),
+            None,
+            120_000,
+            0,
+            DEFAULT_SV1_HASHPOWER,
+            "info".to_string(),
+            "off".to_string(),
+            false,
+            false,
+            false,
+            false,
+            true,
+            None,
+            "3001".to_string(),
+            false,
+            false,
+            "DDxDD".to_string(),
+            None,
+        )
+    }
+
     fn cfg() -> &'static Configuration {
-        CONFIG
-            .get()
-            .expect("Configuration not initialized; call start() first")
+        #[cfg(test)]
+        {
+            return CONFIG.get_or_init(Self::default_for_tests);
+        }
+
+        #[cfg(not(test))]
+        {
+            CONFIG
+                .get()
+                .expect("Configuration not initialized; call start() first")
+        }
     }
 
     pub fn token() -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     path::PathBuf,
+    sync::OnceLock,
     time::Duration,
 };
 use tracing::{debug, error, info};
@@ -16,10 +16,10 @@ use crate::{
     },
     DEFAULT_SV1_HASHPOWER, PRODUCTION_URL, STAGING_URL, TESTNET3_URL,
 };
-lazy_static! {
-    pub static ref CONFIG: Configuration = Configuration::load_config();
-}
-#[derive(Parser)]
+
+static CONFIG: OnceLock<Configuration> = OnceLock::new();
+
+#[derive(Parser, Default)]
 struct Args {
     #[clap(long)]
     staging: bool,
@@ -104,6 +104,7 @@ impl ConfigFile {
     }
 }
 
+#[derive(Debug)]
 pub struct Configuration {
     token: Option<String>,
     tp_address: Option<String>,
@@ -125,12 +126,66 @@ pub struct Configuration {
     miner_name: Option<String>,
 }
 impl Configuration {
+    pub fn new(
+        token: Option<String>,
+        tp_address: Option<String>,
+        interval: u64,
+        delay: u64,
+        downstream_hashrate: f32,
+        loglevel: String,
+        nc_loglevel: String,
+        sv1_log: bool,
+        file_logging: bool,
+        staging: bool,
+        testnet3: bool,
+        local: bool,
+        listening_addr: Option<String>,
+        api_server_port: String,
+        monitor: bool,
+        auto_update: bool,
+        signature: String,
+        miner_name: Option<String>,
+    ) -> Self {
+        Configuration {
+            token,
+            tp_address,
+            interval,
+            delay,
+            downstream_hashrate,
+            loglevel,
+            nc_loglevel,
+            sv1_log,
+            file_logging,
+            staging,
+            testnet3,
+            local,
+            listening_addr,
+            api_server_port,
+            monitor,
+            auto_update,
+            signature,
+            miner_name,
+        }
+    }
+
+    pub(crate) fn init(config: Configuration) {
+        CONFIG
+            .set(config)
+            .expect("Configuration already initialized");
+    }
+
+    fn cfg() -> &'static Configuration {
+        CONFIG
+            .get()
+            .expect("Configuration not initialized; call start() first")
+    }
+
     pub fn token() -> Option<String> {
-        CONFIG.token.clone()
+        Self::cfg().token.clone()
     }
 
     pub fn tp_address() -> Option<String> {
-        CONFIG.tp_address.clone()
+        Self::cfg().tp_address.clone()
     }
 
     pub async fn pool_address() -> Option<Vec<SocketAddr>> {
@@ -144,32 +199,32 @@ impl Configuration {
     }
 
     pub fn adjustment_interval() -> u64 {
-        CONFIG.interval
+        Self::cfg().interval
     }
 
     pub fn delay() -> u64 {
-        CONFIG.delay
+        Self::cfg().delay
     }
 
     pub fn downstream_hashrate() -> f32 {
-        CONFIG.downstream_hashrate
+        Self::cfg().downstream_hashrate
     }
 
     pub fn downstream_listening_addr() -> Option<String> {
-        CONFIG.listening_addr.clone()
+        Self::cfg().listening_addr.clone()
     }
 
     pub fn api_server_port() -> String {
-        CONFIG.api_server_port.clone()
+        Self::cfg().api_server_port.clone()
     }
 
     pub fn loglevel() -> &'static str {
-        match CONFIG.loglevel.to_lowercase().as_str() {
-            "trace" | "debug" | "info" | "warn" | "error" | "off" => &CONFIG.loglevel,
+        match Self::cfg().loglevel.to_lowercase().as_str() {
+            "trace" | "debug" | "info" | "warn" | "error" | "off" => &Self::cfg().loglevel,
             _ => {
                 eprintln!(
                     "Invalid log level '{}'. Defaulting to 'info'.",
-                    CONFIG.loglevel
+                    Self::cfg().loglevel
                 );
                 "info"
             }
@@ -177,12 +232,12 @@ impl Configuration {
     }
 
     pub fn nc_loglevel() -> &'static str {
-        match CONFIG.nc_loglevel.as_str() {
-            "trace" | "debug" | "info" | "warn" | "error" | "off" => &CONFIG.nc_loglevel,
+        match Self::cfg().nc_loglevel.as_str() {
+            "trace" | "debug" | "info" | "warn" | "error" | "off" => &Self::cfg().nc_loglevel,
             _ => {
                 eprintln!(
                     "Invalid log level for noise_connection '{}' Defaulting to 'off'.",
-                    &CONFIG.nc_loglevel
+                    &Self::cfg().nc_loglevel
                 );
                 "off"
             }
@@ -190,33 +245,33 @@ impl Configuration {
     }
 
     pub fn enable_file_logging() -> bool {
-        CONFIG.file_logging
+        Self::cfg().file_logging
     }
     pub fn sv1_ingress_log() -> bool {
-        CONFIG.sv1_log
+        Self::cfg().sv1_log
     }
 
     pub fn staging() -> bool {
-        CONFIG.staging
+        Self::cfg().staging
     }
 
     pub fn local() -> bool {
-        CONFIG.local
+        Self::cfg().local
     }
 
     pub fn testnet3() -> bool {
-        CONFIG.testnet3
+        Self::cfg().testnet3
     }
 
     /// Returns the environment based on the configuration.
     /// Possible values: "staging", "local", "production".
     /// If no environment is set, it defaults to "production".
     pub fn environment() -> String {
-        if CONFIG.staging {
+        if Self::cfg().staging {
             "staging".to_string()
-        } else if CONFIG.local {
+        } else if Self::cfg().local {
             "local".to_string()
-        } else if CONFIG.testnet3 {
+        } else if Self::cfg().testnet3 {
             "testnet3".to_string()
         } else {
             "production".to_string()
@@ -224,25 +279,32 @@ impl Configuration {
     }
 
     pub fn monitor() -> bool {
-        CONFIG.monitor
+        Self::cfg().monitor
     }
 
     pub fn auto_update() -> bool {
-        CONFIG.auto_update
+        Self::cfg().auto_update
     }
 
     pub fn signature() -> String {
-        CONFIG.signature.clone()
+        Self::cfg().signature.clone()
     }
 
     pub fn miner_name() -> Option<String> {
-        CONFIG.miner_name.clone()
+        Self::cfg().miner_name.clone()
     }
 
-    // Loads config from CLI, file, or env vars with precedence: CLI > file > env.
-    fn load_config() -> Self {
+    // Loads config from CLI args, config file, and env vars with precedence: CLI > file > env.
+    pub fn from_cli() -> Self {
         let args = Args::parse();
-        let config_path: PathBuf = args.config_file.unwrap_or("config.toml".into());
+        let config_path: PathBuf = args
+            .config_file
+            .or_else(|| {
+                std::env::var("DMND_CLIENT_CONFIG_FILE")
+                    .ok()
+                    .map(PathBuf::from)
+            })
+            .unwrap_or("config.toml".into());
         let config: ConfigFile = std::fs::read_to_string(&config_path)
             .ok()
             .and_then(|content| toml::from_str(&content).ok())
@@ -445,15 +507,15 @@ fn parse_address(addr: String) -> Option<SocketAddr> {
 
 /// Fetches pool URLs from the server based on the environment.
 async fn fetch_pool_urls() -> Result<Vec<SocketAddr>, Error> {
-    if CONFIG.local {
+    if Configuration::cfg().local {
         info!("Running in local mode, using hardcoded address 127.0.0.1:20000");
         return Ok(vec![
             parse_address("127.0.0.1:20000".to_string()).expect("Invalid local address")
         ]);
     };
-    let url = if CONFIG.staging {
+    let url = if Configuration::cfg().staging {
         STAGING_URL
-    } else if CONFIG.testnet3 {
+    } else if Configuration::cfg().testnet3 {
         TESTNET3_URL
     } else {
         PRODUCTION_URL

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,7 @@ pub struct Configuration {
     miner_name: Option<String>,
 }
 impl Configuration {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         token: Option<String>,
         tp_address: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,7 +202,7 @@ impl Configuration {
     fn cfg() -> &'static Configuration {
         #[cfg(test)]
         {
-            return CONFIG.get_or_init(Self::default_for_tests);
+            CONFIG.get_or_init(Self::default_for_tests)
         }
 
         #[cfg(not(test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,19 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(test)]
+use integration_tests_sv2 as _;
+#[cfg(test)]
+use stratum_apps as _;
+
+#[cfg(all(not(target_os = "windows"), feature = "jemalloc"))]
 use jemallocator::Jemalloc;
 use router::Router;
 use tokio::sync::watch;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "jemalloc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
 use crate::auto_update::check_update_proxy;
 use crate::shared::utils::AbortOnDrop;
-use config::Configuration;
 use key_utils::Secp256k1PublicKey;
 use lazy_static::lazy_static;
 use proxy_state::{PoolState, ProxyState, TpState, TranslatorState};
@@ -22,6 +26,7 @@ mod api;
 mod auto_update;
 mod config;
 mod ingress;
+pub use config::Configuration;
 pub mod jd_client;
 mod minin_pool_connection;
 mod monitor;
@@ -55,14 +60,12 @@ lazy_static! {
 }
 
 lazy_static! {
-
-    // for staging and local environments, use the test auth public key
-    // for production, use the main auth public key
-    pub static ref AUTH_PUB_KEY: &'static str = if Configuration::staging() || Configuration::local() || Configuration::testnet3() {
-        TEST_AUTH_PUB_KEY
-    } else {
-        MAIN_AUTH_PUB_KEY
-    };
+    pub static ref AUTH_PUB_KEY: &'static str =
+        if Configuration::staging() || Configuration::local() || Configuration::testnet3() {
+            TEST_AUTH_PUB_KEY
+        } else {
+            MAIN_AUTH_PUB_KEY
+        };
 }
 lazy_static! {
     static ref SHARE_PER_MIN: f32 = std::env::var("SHARE_PER_MIN")
@@ -73,7 +76,12 @@ lazy_static! {
 
 static LOG_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 
-pub async fn start() {
+pub async fn start(config: Configuration) {
+    Configuration::init(config);
+    start_internal().await;
+}
+
+async fn start_internal() {
     let log_level = Configuration::loglevel();
     let noise_connection_log_level = Configuration::nc_loglevel();
 
@@ -90,7 +98,7 @@ pub async fn start() {
             "{log_level},demand_sv2_connection::noise_connection_tokio={noise_connection_log_level}"
         )));
 
-    if enable_file_logging {
+    let tracing_init_result = if enable_file_logging {
         let file_appender = tracing_appender::rolling::daily("logs", "dmnd-client.log");
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         LOG_GUARD.set(guard).unwrap_or(());
@@ -104,12 +112,16 @@ pub async fn start() {
             .with(console_layer)
             .with(file_layer)
             // .with(remote_layer)
-            .init();
+            .try_init()
     } else {
         tracing_subscriber::registry()
             .with(console_layer)
             // .with(remote_layer)
-            .init();
+            .try_init()
+    };
+
+    if let Err(e) = tracing_init_result {
+        eprintln!("Tracing subscriber already set, skipping: {e}");
     }
 
     Configuration::token().expect("TOKEN is not set");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-#![allow(unused_crate_dependencies)] // To avoid warnings about unused dependencies in this binary crate since the dependencies are used in the library crate.
+#![allow(unused_crate_dependencies)]
 #[tokio::main]
 async fn main() {
-    dmnd_client::start().await;
+    let config = dmnd_client::Configuration::from_cli();
+    dmnd_client::start(config).await;
 }

--- a/tests/library_init.rs
+++ b/tests/library_init.rs
@@ -1,0 +1,164 @@
+#![allow(unused_crate_dependencies)]
+
+use std::{
+    net::{SocketAddr, TcpListener},
+    time::Duration,
+};
+
+use integration_tests_sv2::{
+    interceptor::MessageDirection,
+    mock_roles::{MockUpstream, WithSetup},
+    sniffer::Sniffer,
+    start_template_provider,
+    template_provider::DifficultyLevel,
+    utils::get_available_address,
+};
+use stratum_apps::stratum_core::common_messages_sv2::{
+    Protocol, MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+};
+
+fn ensure_port_free_or_skip(address: &str) -> bool {
+    match TcpListener::bind(address) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            eprintln!("skipping: {address} is in use");
+            false
+        }
+        Err(e) => panic!("failed to probe {address}: {e}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn library_init_sv2_setup_connection() {
+    if !ensure_port_free_or_skip("127.0.0.1:20000") {
+        return;
+    }
+    if !ensure_port_free_or_skip("127.0.0.1:20001") {
+        return;
+    }
+    if !ensure_port_free_or_skip("127.0.0.1:20002") {
+        return;
+    }
+
+    let proxy_target: SocketAddr = "127.0.0.1:20000".parse().unwrap();
+    let mock_pool_mining_addr: SocketAddr = "127.0.0.1:20001".parse().unwrap();
+    let mock_pool_jd_addr: SocketAddr = "127.0.0.1:20002".parse().unwrap();
+    let tp_sniffer_addr = get_available_address();
+    let (template_provider, template_provider_addr) =
+        start_template_provider(Some(1), DifficultyLevel::Low);
+
+    let _mock_pool_mining = MockUpstream::new(
+        mock_pool_mining_addr,
+        WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0),
+    )
+    .start()
+    .await;
+
+    let _mock_pool_jd = MockUpstream::new(
+        mock_pool_jd_addr,
+        WithSetup::yes_with_defaults(Protocol::JobDeclarationProtocol, 0),
+    )
+    .start()
+    .await;
+
+    let pool_sniffer = Sniffer::new(
+        "proxy-pool-mining",
+        proxy_target,
+        mock_pool_mining_addr,
+        false,
+        vec![],
+        Some(30),
+    );
+    pool_sniffer.start();
+
+    let jd_pool_sniffer = Sniffer::new(
+        "proxy-pool-jd",
+        proxy_target,
+        mock_pool_jd_addr,
+        false,
+        vec![],
+        Some(30),
+    );
+    {
+        let jd_pool_sniffer = jd_pool_sniffer.clone();
+        tokio::spawn(async move {
+            loop {
+                if let Ok(listener) = TcpListener::bind("127.0.0.1:20000") {
+                    drop(listener);
+                    jd_pool_sniffer.start();
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        });
+    }
+
+    let tp_sniffer = Sniffer::new(
+        "proxy-tp",
+        tp_sniffer_addr,
+        template_provider_addr,
+        false,
+        vec![],
+        Some(30),
+    );
+    tp_sniffer.start();
+
+    let config = dmnd_client::Configuration::new(
+        Some("test_token".to_string()),
+        Some(tp_sniffer_addr.to_string()),
+        120_000,
+        0,
+        100_000_000_000_000.0,
+        "info".to_string(),
+        "off".to_string(),
+        false,
+        false,
+        false,
+        false,
+        true,
+        None,
+        "3001".to_string(),
+        false,
+        false,
+        "DDxDD".to_string(),
+        None,
+    );
+
+    let proxy = tokio::spawn(dmnd_client::start(config));
+
+    pool_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+
+    pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    jd_pool_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+
+    jd_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    tp_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+
+    tp_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    proxy.abort();
+    drop(template_provider);
+}


### PR DESCRIPTION
Closes #198

## Context

Right now if you try to use `dmnd-client` as a library dependency (like `dmnd-splitter` wants to), things break pretty quickly. I dug into the root causes and found four main blockers:

1. The `#[global_allocator]` in `lib.rs` unconditionally sets jemalloc — so any host binary that uses its own allocator gets conflicts.
2. The `Configuration` singleton calls `Args::parse()` on init, which means it tries to parse the *host process's* CLI flags and crashes.
3. `tracing_subscriber::registry().init()` panics if the host already set up a subscriber.
4. The auto-update logic can call `process::exit()` or even replace the running binary, which obviously isn't safe when you're embedded inside someone else's process.

## What this PR does

**Feature-gate jemalloc:** Added a `jemalloc` cargo feature that's on by default, so the binary works exactly as before. Library consumers just add `default-features = false` and the allocator stays out of their way.

**Split the startup path:** There are now two entry points , `start()` for library use (reads config from env vars and config file only, no CLI parsing, auto-update off by default) and `start_from_cli()` which is what `main.rs` calls and behaves identically to before.

**Swap `lazy_static! CONFIG` for `OnceLock`:** Config gets initialized explicitly by `start()` or `start_from_cli()` before anything else touches it. I traced through the execution order and confirmed all the lazy_static globals (`TP_ADDRESS`, `AUTH_PUB_KEY`, `SHARE_PER_MIN`) are only accessed after config is already set up.

**Use `.try_init()` for tracing:** Instead of panicking when a subscriber already exists, it just logs a warning and moves on.

## How a library consumer uses this

```toml
[dependencies]
dmnd-client = { git = "...", default-features = false }
```

```rust
dmnd_client::start().await;
```