### PR TITLE
Fix race condition in SharesMonitor that drops shares during send

### DIFF
--- a/src/monitor/shares.rs
+++ b/src/monitor/shares.rs
@@ -68,27 +68,11 @@ impl SharesMonitor {
             });
     }
 
-    /// Retrieves the list of pending shares.
-    fn get_next_shares(&self) -> Vec<ShareInfo> {
-        self.shares
-            .safe_lock(|event| event.clone())
-            .unwrap_or_else(|e| {
-                error!("Failed to lock pending shares: {:?}", e);
-                ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
-                Vec::new()
-            })
-    }
-
-    /// Clears the list of pending shares.
-    fn clear_next_shares(&self) {
-        self.shares
-            .safe_lock(|event| {
-                event.clear();
-            })
-            .unwrap_or_else(|e| {
-                error!("Failed to lock pending shares: {:?}", e);
-                ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
-            });
+    /// Atomically takes all pending shares, leaving the internal list empty for new
+    /// shares. This avoids the race condition where a clone + clear would drop shares
+    /// inserted between the two operations.
+    fn take_shares(&self) -> Vec<ShareInfo> {
+        self.shares.safe_lock(std::mem::take).unwrap_or_default()
     }
 
     pub async fn monitor(&self) {
@@ -100,19 +84,16 @@ impl SharesMonitor {
         interval.tick().await;
         loop {
             interval.tick().await;
-            let shares_to_send = self.get_next_shares();
+            let shares_to_send = self.take_shares();
             if !shares_to_send.is_empty() {
                 let token = self.token.safe_lock(|t| t.clone()).unwrap();
-                match api.send_shares(shares_to_send.clone(), &token).await {
+                let batch_len = shares_to_send.len();
+                match api.send_shares(shares_to_send, &token).await {
                     Ok(_) => {
-                        info!(
-                            "Saved {} shares to the monitoring server",
-                            shares_to_send.len()
-                        );
-                        self.clear_next_shares();
+                        info!("Saved {} shares to the monitoring server", batch_len);
                     }
                     Err(err) => {
-                        warn!("Failed to send shares, this does not affect mining but may cause issues with monitoring: {:?}", err);
+                        warn!("Failed to send {} shares, this does not affect mining but may cause issues with monitoring: {:?}", batch_len, err);
                     }
                 }
             } else {
@@ -138,5 +119,87 @@ impl std::fmt::Display for RejectionReason {
             RejectionReason::InvalidJobIdFormat => write!(f, "Invalid job ID format"),
             RejectionReason::DifficultyMismatch => write!(f, "Difficulty mismatch"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn token() -> Arc<Mutex<String>> {
+        Arc::new(Mutex::new(String::from("test-token")))
+    }
+
+    fn make_share(name: &str, job_id: i64) -> ShareInfo {
+        ShareInfo::new(name.to_string(), Some(1.0), job_id, 0, None)
+    }
+
+    #[test]
+    fn insert_then_take_returns_all_inserted() {
+        let m = SharesMonitor::new(token());
+        m.insert_share(make_share("w1", 1));
+        m.insert_share(make_share("w2", 2));
+
+        let taken = m.take_shares();
+        assert_eq!(taken.len(), 2);
+        assert_eq!(taken[0].worker_name, "w1");
+        assert_eq!(taken[1].worker_name, "w2");
+    }
+
+    #[test]
+    fn take_drains_internal_state() {
+        let m = SharesMonitor::new(token());
+        m.insert_share(make_share("w1", 1));
+        let _ = m.take_shares();
+        assert!(m.take_shares().is_empty());
+    }
+
+    #[test]
+    fn take_on_empty_returns_empty() {
+        let m = SharesMonitor::new(token());
+        assert!(m.take_shares().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_insert_and_take_loses_nothing() {
+        const WORKERS: usize = 8;
+        const PER_WORKER: i64 = 200;
+
+        let m = SharesMonitor::new(token());
+        let total_taken = Arc::new(AtomicUsize::new(0));
+
+        let inserters: Vec<_> = (0..WORKERS)
+            .map(|w| {
+                let m = m.clone();
+                tokio::spawn(async move {
+                    for j in 0..PER_WORKER {
+                        m.insert_share(make_share(&format!("w{w}"), j));
+                        tokio::task::yield_now().await;
+                    }
+                })
+            })
+            .collect();
+
+        let taker = {
+            let m = m.clone();
+            let total = total_taken.clone();
+            tokio::spawn(async move {
+                for _ in 0..50 {
+                    let batch = m.take_shares();
+                    total.fetch_add(batch.len(), Ordering::Relaxed);
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        for h in inserters {
+            h.await.unwrap();
+        }
+        taker.await.unwrap();
+
+        let tail = m.take_shares().len();
+        let taken = total_taken.load(Ordering::Relaxed) + tail;
+        assert_eq!(taken, WORKERS * PER_WORKER as usize);
     }
 }


### PR DESCRIPTION
The share monitor had a race condition where shares could get silently dropped. get_next_shares() clones the vec, then after the HTTP send  finishes, clear_next_shares() wipes everything including shares that miners pushed while the request was in flight. Replaced the clone+clear with std::mem::take so it atomically moves shares out in one lock, and new shares that come in during the send just go into the fresh empty vec. Also added a requeue on send failure so shares don't get lost if the monitoring server is down.
