### PR TITLE
Forward shares meeting any tracked difficulty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.2.9"
+version = "0.3.1"
 dependencies = [
  "async-recursion",
  "axum",

--- a/src/monitor/shares.rs
+++ b/src/monitor/shares.rs
@@ -127,7 +127,6 @@ pub enum RejectionReason {
     JobIdNotFound,
     InvalidShare,
     InvalidJobIdFormat,
-    DifficultyMismatch,
 }
 
 impl std::fmt::Display for RejectionReason {
@@ -136,7 +135,6 @@ impl std::fmt::Display for RejectionReason {
             RejectionReason::JobIdNotFound => write!(f, "Job ID not found"),
             RejectionReason::InvalidShare => write!(f, "Invalid share"),
             RejectionReason::InvalidJobIdFormat => write!(f, "Invalid job ID format"),
-            RejectionReason::DifficultyMismatch => write!(f, "Difficulty mismatch"),
         }
     }
 }

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -577,46 +577,29 @@ impl IsServer<'static> for Downstream {
                 self.extranonce1.clone(),
                 self.version_rolling_mask.clone(),
             ) {
-                // Only forward upstream if the share meets the latest difficulty
-                if let Some(latest_difficulty) = self.difficulty_mgmt.current_difficulties.back() {
-                    if met_difficulty == *latest_difficulty {
-                        let to_send = SubmitShareWithChannelId {
-                            channel_id: self.connection_id,
-                            share: request.clone(),
-                            extranonce: self.extranonce1.clone(),
-                            extranonce2_len: self.extranonce2_len,
-                            version_rolling_mask: self.version_rolling_mask.clone(),
-                        };
-                        if let Err(e) = self
-                            .tx_sv1_bridge
-                            .try_send(DownstreamMessages::SubmitShares(to_send))
-                        {
-                            error!("Failed to start receive downstream task: {e:?}");
-                            self.stats_sender.update_rejected_shares(self.connection_id);
-                            // Return false because submit was not properly handled
-                            return false;
-                        }
-                        // Share is accepted here
-                        let share = ShareInfo::new(
-                            request.user_name.clone(),
-                            Some(met_difficulty),
-                            job_id,
-                            nonce,
-                            None,
-                        );
-                        self.share_monitor.insert_share(share);
-                    } else {
-                        // met_difficulty is not latest difficulty, so we mark it as rejected
-                        let share = ShareInfo::new(
-                            request.user_name.clone(),
-                            None,
-                            job_id, // rejected because it was not sent upstream
-                            nonce,
-                            Some(RejectionReason::DifficultyMismatch),
-                        );
-                        self.share_monitor.insert_share(share);
-                    }
+                let to_send = SubmitShareWithChannelId {
+                    channel_id: self.connection_id,
+                    share: request.clone(),
+                    extranonce: self.extranonce1.clone(),
+                    extranonce2_len: self.extranonce2_len,
+                    version_rolling_mask: self.version_rolling_mask.clone(),
+                };
+                if let Err(e) = self
+                    .tx_sv1_bridge
+                    .try_send(DownstreamMessages::SubmitShares(to_send))
+                {
+                    error!("Failed to forward share to bridge: {e:?}");
+                    self.stats_sender.update_rejected_shares(self.connection_id);
+                    return false;
                 }
+                let share = ShareInfo::new(
+                    request.user_name.clone(),
+                    Some(met_difficulty),
+                    job_id,
+                    nonce,
+                    None,
+                );
+                self.share_monitor.insert_share(share);
                 self.stats_sender.update_accepted_shares(self.connection_id);
                 info!(
                     "Share for Job {} and difficulty {} is accepted",


### PR DESCRIPTION

## Body

shares that meet an old but still-tracked diff get marked rejected and never reach the pool. on top of that, `update_accepted_shares` fires whenever `validate_share` returns `Some`, so the old else branch was bumping accepted AND inserting a rejection record for the same share. counters drift hard from the pool view.

based on what you flagged in #176 (pool accepts shares across the last few jobs, not just the latest diff), this removes the `met_difficulty == latest_difficulty` filter. if `validate_share` returns `Some`, the share is forwarded. if `try_send` fails, it is rejected as before.

`DifficultyMismatch` is unused after this change and has been removed.

### why this is safe

`RecentJobs` already tracks the last 3 v2 jobs via `CircularBuffer<u32, 3>`, so the set of difficulties accepted by `validate_share` matches the pool’s 3-job window.

### notes

- `cargo check` clean (only pre-existing manifest warnings)
- no new tests — `handle_submit` stub at `downstream.rs:856` is commented out so there’s nothing to extend yet  
  (happy to add a new test module here if preferred instead of a follow-up)

fixes #152