### PR TITLE
FIX reject invalid shares when difficulty updates are disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmnd-client"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 
 [lib]

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -591,22 +591,9 @@ impl IsServer<'static> for Downstream {
             .get_matching_job(job_id_as_number.expect("checked above"))
         {
             request.job_id = job.job_id.clone();
-            if Configuration::difficulty_updates_disabled() {
-                if !self.forward_submit_share(request.clone()) {
-                    return false;
-                }
 
-                let share = ShareInfo::new(request.user_name.clone(), None, job_id, nonce, None);
-                self.share_monitor.insert_share(share);
-                self.stats_sender.update_accepted_shares(self.connection_id);
-                info!(
-                    "Share for Job {} forwarded with local difficulty management disabled",
-                    request.job_id
-                );
-                return true;
-            }
-
-            //check share is valid
+            // Shares must always be validated locally. Disabling difficulty updates only
+            // disables downstream/internal retargeting, not share validation itself.
             if let Some(met_difficulty) = validate_share(
                 &request,
                 &job,
@@ -643,10 +630,10 @@ impl IsServer<'static> for Downstream {
                     }
                 }
                 self.stats_sender.update_accepted_shares(self.connection_id);
-                info!(
-                    "Share for Job {} and difficulty {} is accepted",
-                    request.job_id, met_difficulty
-                );
+                //info!(
+                //    "Share for Job {} and difficulty {} is accepted",
+                //    request.job_id, met_difficulty
+                //);
                 true
             } else {
                 let share = ShareInfo::new(

--- a/src/translator/utils.rs
+++ b/src/translator/utils.rs
@@ -18,7 +18,7 @@ use bitcoin::{
 use lazy_static::lazy_static;
 use roles_logic_sv2::utils::Mutex;
 use sv1_api::{client_to_server, server_to_client::Notify};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use super::downstream::Downstream;
 lazy_static! {
@@ -113,10 +113,10 @@ pub fn validate_share(
     extranonce1: Vec<u8>,
     version_rolling_mask: Option<sv1_api::utils::HexU32Be>,
 ) -> Option<f32> {
-    info!(
-        "Validating share from request {} and job {}",
-        request.id, request.job_id
-    );
+    //info!(
+    //    "Validating share from request {} and job {}",
+    //    request.id, request.job_id
+    //);
 
     let prev_hash_vec: Vec<u8> = job.prev_hash.clone().into();
     let prev_hash = match binary_sv2::U256::from_vec_(prev_hash_vec) {
@@ -158,9 +158,9 @@ pub fn validate_share(
     );
 
     hash.reverse(); //convert to little-endian
-    info!("Share Hash: {:?}", hash.to_vec().as_hex());
-    // Check against difficulties from latest to earliest
-    // TODO: This is not a sound check - We should check against the difficulty of the specific job
+                    //info!("Share Hash: {:?}", hash.to_vec().as_hex());
+                    // Check against difficulties from latest to earliest
+                    // TODO: This is not a sound check - We should check against the difficulty of the specific job
     for &difficulty in difficulties.iter().rev() {
         let target = Downstream::difficulty_to_target(difficulty);
         debug!(
@@ -169,7 +169,7 @@ pub fn validate_share(
             target.to_vec().as_hex()
         );
         if hash <= target {
-            info!("Share met Target: {:?}", target.to_vec().as_hex());
+            //info!("Share met Target: {:?}", target.to_vec().as_hex());
             return Some(difficulty); // Return the difficulty met
         }
     }


### PR DESCRIPTION
Disabling difficulty updates only freezes downstream and internal retargeting. The proxy still validates submitted shares against the fixed assigned difficulty so invalid shares are rejected instead of being forwarded upstream as accepted work.