### PR TITLE
FIX stop deferred downstream bootstrap from reviving closed miner ses…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -234,7 +234,7 @@ impl Configuration {
             false,
             true,
             None,
-            Some(8000),
+            Some(8001),
             250,
             16_384,
             Some(512),
@@ -515,7 +515,7 @@ impl Configuration {
                     .ok()
                     .and_then(|s| s.parse().ok())
             })
-            .or(Some(8000))
+            .or(Some(8001))
             .filter(|value| *value > 0);
         let accept_backoff_ms = args
             .accept_backoff_ms

--- a/src/debug_timing.rs
+++ b/src/debug_timing.rs
@@ -1,0 +1,240 @@
+use serde::Serialize;
+use std::{
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SessionTimingStage {
+    AcceptQueueWait,
+    BridgeOpen,
+    DownstreamInit,
+    AcceptToDownstreamReady,
+    AcceptToSubscribe,
+    AcceptToAuthorize,
+    AcceptToFirstNotify,
+}
+
+#[derive(Debug)]
+pub(crate) struct DownstreamSessionTiming {
+    accepted_at: Instant,
+    subscribe_recorded: bool,
+    authorize_recorded: bool,
+    first_notify_recorded: bool,
+}
+
+impl DownstreamSessionTiming {
+    pub(crate) fn new(accepted_at: Instant) -> Self {
+        Self {
+            accepted_at,
+            subscribe_recorded: false,
+            authorize_recorded: false,
+            first_notify_recorded: false,
+        }
+    }
+
+    pub(crate) fn record_subscribe_if_needed(&mut self) {
+        if !self.subscribe_recorded {
+            record_stage(
+                SessionTimingStage::AcceptToSubscribe,
+                self.accepted_at.elapsed(),
+            );
+            self.subscribe_recorded = true;
+        }
+    }
+
+    pub(crate) fn record_authorize_if_needed(&mut self) {
+        if !self.authorize_recorded {
+            record_stage(
+                SessionTimingStage::AcceptToAuthorize,
+                self.accepted_at.elapsed(),
+            );
+            self.authorize_recorded = true;
+        }
+    }
+
+    pub(crate) fn record_first_notify_if_needed(&mut self) {
+        if !self.first_notify_recorded {
+            record_stage(
+                SessionTimingStage::AcceptToFirstNotify,
+                self.accepted_at.elapsed(),
+            );
+            self.first_notify_recorded = true;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionStageStats {
+    pub count: usize,
+    pub min_ms: f64,
+    pub avg_ms: f64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub max_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionTimingSnapshot {
+    pub enabled: bool,
+    pub accept_queue_wait: Option<SessionStageStats>,
+    pub bridge_open: Option<SessionStageStats>,
+    pub downstream_init: Option<SessionStageStats>,
+    pub accept_to_downstream_ready: Option<SessionStageStats>,
+    pub accept_to_subscribe: Option<SessionStageStats>,
+    pub accept_to_authorize: Option<SessionStageStats>,
+    pub accept_to_first_notify: Option<SessionStageStats>,
+}
+
+#[derive(Debug, Default)]
+struct SessionTimingCollector {
+    accept_queue_wait_us: Vec<u64>,
+    bridge_open_us: Vec<u64>,
+    downstream_init_us: Vec<u64>,
+    accept_to_downstream_ready_us: Vec<u64>,
+    accept_to_subscribe_us: Vec<u64>,
+    accept_to_authorize_us: Vec<u64>,
+    accept_to_first_notify_us: Vec<u64>,
+}
+
+impl SessionTimingCollector {
+    fn record(&mut self, stage: SessionTimingStage, duration: Duration) {
+        let micros = duration.as_micros().min(u64::MAX as u128) as u64;
+        match stage {
+            SessionTimingStage::AcceptQueueWait => self.accept_queue_wait_us.push(micros),
+            SessionTimingStage::BridgeOpen => self.bridge_open_us.push(micros),
+            SessionTimingStage::DownstreamInit => self.downstream_init_us.push(micros),
+            SessionTimingStage::AcceptToDownstreamReady => {
+                self.accept_to_downstream_ready_us.push(micros)
+            }
+            SessionTimingStage::AcceptToSubscribe => self.accept_to_subscribe_us.push(micros),
+            SessionTimingStage::AcceptToAuthorize => self.accept_to_authorize_us.push(micros),
+            SessionTimingStage::AcceptToFirstNotify => self.accept_to_first_notify_us.push(micros),
+        }
+    }
+
+    fn snapshot(&self) -> SessionTimingSnapshot {
+        SessionTimingSnapshot {
+            enabled: true,
+            accept_queue_wait: stage_stats(&self.accept_queue_wait_us),
+            bridge_open: stage_stats(&self.bridge_open_us),
+            downstream_init: stage_stats(&self.downstream_init_us),
+            accept_to_downstream_ready: stage_stats(&self.accept_to_downstream_ready_us),
+            accept_to_subscribe: stage_stats(&self.accept_to_subscribe_us),
+            accept_to_authorize: stage_stats(&self.accept_to_authorize_us),
+            accept_to_first_notify: stage_stats(&self.accept_to_first_notify_us),
+        }
+    }
+}
+
+fn stage_stats(samples_us: &[u64]) -> Option<SessionStageStats> {
+    if samples_us.is_empty() {
+        return None;
+    }
+
+    let mut ordered = samples_us.to_vec();
+    ordered.sort_unstable();
+    let count = ordered.len();
+    let sum_us: u128 = ordered.iter().map(|value| *value as u128).sum();
+
+    Some(SessionStageStats {
+        count,
+        min_ms: ordered[0] as f64 / 1000.0,
+        avg_ms: (sum_us as f64 / count as f64) / 1000.0,
+        p50_ms: percentile_ms(&ordered, 0.50),
+        p95_ms: percentile_ms(&ordered, 0.95),
+        max_ms: ordered[count - 1] as f64 / 1000.0,
+    })
+}
+
+fn percentile_ms(samples_us: &[u64], percentile: f64) -> f64 {
+    let last_index = samples_us.len().saturating_sub(1);
+    let index = ((last_index as f64) * percentile).round() as usize;
+    samples_us[index.min(last_index)] as f64 / 1000.0
+}
+
+fn parse_enabled_flag(value: &str) -> bool {
+    !matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "off" | "no"
+    )
+}
+
+static SESSION_TIMING_ENABLED: OnceLock<bool> = OnceLock::new();
+static SESSION_TIMING_COLLECTOR: OnceLock<Mutex<SessionTimingCollector>> = OnceLock::new();
+
+pub fn session_timing_enabled() -> bool {
+    *SESSION_TIMING_ENABLED.get_or_init(|| {
+        std::env::var("SV1_SESSION_TIMING")
+            .map(|value| parse_enabled_flag(&value))
+            .unwrap_or(false)
+    })
+}
+
+pub fn record_stage(stage: SessionTimingStage, duration: Duration) {
+    if !session_timing_enabled() {
+        return;
+    }
+
+    let collector =
+        SESSION_TIMING_COLLECTOR.get_or_init(|| Mutex::new(SessionTimingCollector::default()));
+    if let Ok(mut collector) = collector.lock() {
+        collector.record(stage, duration);
+    }
+}
+
+pub fn snapshot() -> SessionTimingSnapshot {
+    if !session_timing_enabled() {
+        return SessionTimingSnapshot {
+            enabled: false,
+            accept_queue_wait: None,
+            bridge_open: None,
+            downstream_init: None,
+            accept_to_downstream_ready: None,
+            accept_to_subscribe: None,
+            accept_to_authorize: None,
+            accept_to_first_notify: None,
+        };
+    }
+
+    SESSION_TIMING_COLLECTOR
+        .get_or_init(|| Mutex::new(SessionTimingCollector::default()))
+        .lock()
+        .map(|collector| collector.snapshot())
+        .unwrap_or(SessionTimingSnapshot {
+            enabled: true,
+            accept_queue_wait: None,
+            bridge_open: None,
+            downstream_init: None,
+            accept_to_downstream_ready: None,
+            accept_to_subscribe: None,
+            accept_to_authorize: None,
+            accept_to_first_notify: None,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_enabled_flag, stage_stats};
+
+    #[test]
+    fn stage_stats_compute_basic_percentiles() {
+        let stats = stage_stats(&[1_000, 2_000, 3_000, 4_000, 5_000]).expect("stats");
+        assert_eq!(stats.count, 5);
+        assert!((stats.min_ms - 1.0).abs() < f64::EPSILON);
+        assert!((stats.avg_ms - 3.0).abs() < f64::EPSILON);
+        assert!((stats.p50_ms - 3.0).abs() < f64::EPSILON);
+        assert!((stats.p95_ms - 5.0).abs() < f64::EPSILON);
+        assert!((stats.max_ms - 5.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn enabled_flag_parser_handles_common_false_values() {
+        for value in ["0", "false", "False", "off", "no"] {
+            assert!(!parse_enabled_flag(value));
+        }
+        for value in ["1", "true", "yes", "debug"] {
+            assert!(parse_enabled_flag(value));
+        }
+    }
+}

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -128,6 +128,7 @@ pub struct Downstream {
     tx_update_token: Sender<String>,
     pub session_timing: std::cell::RefCell<DownstreamSessionTiming>,
     submit_counts_for_diff: Cell<bool>,
+    closed: Cell<bool>,
 }
 
 impl Downstream {
@@ -219,6 +220,7 @@ impl Downstream {
             tx_update_token,
             session_timing: std::cell::RefCell::new(DownstreamSessionTiming::new(accepted_at)),
             submit_counts_for_diff: Cell::new(false),
+            closed: Cell::new(false),
         }));
 
         if let Err(e) = start_receive_downstream(
@@ -249,7 +251,18 @@ impl Downstream {
         // Notify/bootstrap and share-monitor startup are not required before the miner can
         // receive subscribe/authorize responses. Defer them off the connection-open critical
         // path so startup slots are held only for the bidirectional SV1 relay tasks.
-        tokio::spawn(async move {
+        let bootstrap_registration_manager = task_manager.clone();
+        let bootstrap_handle = tokio::spawn(async move {
+            let should_skip_bootstrap =
+                downstream.safe_lock(|d| d.is_closed()).unwrap_or_else(|e| {
+                    error!("Failed to read downstream closed state for bootstrap: {e}");
+                    ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+                    true
+                });
+            if should_skip_bootstrap {
+                return;
+            }
+
             if let Err(e) = start_notify(
                 task_manager.clone(),
                 downstream.clone(),
@@ -263,6 +276,16 @@ impl Downstream {
                 ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
             };
 
+            let should_skip_share_monitor =
+                downstream.safe_lock(|d| d.is_closed()).unwrap_or_else(|e| {
+                    error!("Failed to read downstream closed state before share monitor: {e}");
+                    ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+                    true
+                });
+            if should_skip_share_monitor {
+                return;
+            }
+
             if let Err(e) =
                 Self::start_share_monitor(task_manager.clone(), downstream.clone()).await
             {
@@ -270,6 +293,16 @@ impl Downstream {
                 ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
             }
         });
+        if let Err(e) = TaskManager::add_bootstrap(
+            bootstrap_registration_manager,
+            bootstrap_handle.into(),
+            connection_id,
+        )
+        .await
+        {
+            error!("Failed to register bootstrap task for downstream {connection_id}: {e:?}");
+            ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+        }
     }
 
     /// Starts the shares monitor task.
@@ -277,6 +310,11 @@ impl Downstream {
         task_manager: Arc<Mutex<TaskManager>>,
         downstream: Arc<Mutex<Self>>,
     ) -> Result<(), Error<'static>> {
+        let is_closed = downstream.safe_lock(|s| s.is_closed())?;
+        if is_closed {
+            return Ok(());
+        }
+
         let (share_monitor, connection_id) =
             downstream.safe_lock(|s| (s.share_monitor.clone(), s.connection_id))?;
 
@@ -546,6 +584,7 @@ impl Downstream {
                 std::time::Instant::now(),
             )),
             submit_counts_for_diff: Cell::new(false),
+            closed: Cell::new(false),
         }
     }
 
@@ -555,6 +594,14 @@ impl Downstream {
 
     pub(super) fn take_submit_diff_count_flag(&self) -> bool {
         self.submit_counts_for_diff.replace(false)
+    }
+
+    pub(super) fn mark_closed(&self) {
+        self.closed.set(true);
+    }
+
+    pub(super) fn is_closed(&self) -> bool {
+        self.closed.get()
     }
 }
 

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -31,6 +31,11 @@ pub async fn start_notify(
     host: String,
     connection_id: u32,
 ) -> Result<(), Error<'static>> {
+    let is_closed = downstream.safe_lock(|d| d.is_closed())?;
+    if is_closed {
+        return Ok(());
+    }
+
     let handle = {
         let task_manager = task_manager.clone();
         let (upstream_difficulty_config, stats_sender, latest_diff) =
@@ -46,6 +51,21 @@ pub async fn start_notify(
         if let Err(e) = stats_sender.setup_stats_reliable(connection_id).await {
             error!("Failed to register downstream stats {connection_id}: {e}");
         }
+
+        let is_closed = downstream.safe_lock(|d| d.is_closed())?;
+        if is_closed {
+            if let Err(e) = stats_sender.remove_stats_reliable(connection_id).await {
+                error!("Failed to rollback downstream stats {connection_id}: {e}");
+            }
+            upstream_difficulty_config.safe_lock(|u| {
+                u.channel_nominal_hashrate -= f32::min(
+                    Configuration::downstream_hashrate(),
+                    u.channel_nominal_hashrate,
+                );
+            })?;
+            return Ok(());
+        }
+
         task::spawn(async move {
             let timeout_timer = std::time::Instant::now();
             let mut authorized_in_time = true;

--- a/src/translator/downstream/receive_from_downstream.rs
+++ b/src/translator/downstream/receive_from_downstream.rs
@@ -68,6 +68,9 @@ pub async fn start_receive_downstream(
                     return;
                 }
             }
+            if let Err(e) = downstream.safe_lock(|d| d.mark_closed()) {
+                error!("Failed to mark downstream {connection_id} closed: {e}");
+            }
             let stats_sender = downstream.safe_lock(|d| d.stats_sender.clone()).ok();
             if let Some(stats_sender) = stats_sender {
                 if let Err(e) = stats_sender.remove_stats_reliable(connection_id).await {

--- a/src/translator/downstream/task_manager.rs
+++ b/src/translator/downstream/task_manager.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 #[allow(dead_code)]
 enum Task {
     AcceptConnection(AbortOnDrop),
+    Bootstrap(AbortOnDrop),
     ReceiveDownstream(AbortOnDrop),
     SendDownstream(AbortOnDrop),
     Notify(AbortOnDrop),
@@ -102,6 +103,17 @@ impl TaskManager {
             .await
             .map_err(|_| ())
     }
+    pub async fn add_bootstrap(
+        self_: Arc<Mutex<Self>>,
+        abortable: AbortOnDrop,
+        connection_id: u32,
+    ) -> Result<(), ()> {
+        let send_task = self_.safe_lock(|s| s.send_task.clone()).unwrap();
+        send_task
+            .send((Some(connection_id), Task::Bootstrap(abortable)))
+            .await
+            .map_err(|_| ())
+    }
     pub async fn add_update(
         self_: Arc<Mutex<Self>>,
         abortable: AbortOnDrop,
@@ -163,6 +175,7 @@ impl From<Task> for AbortOnDrop {
     fn from(task: Task) -> Self {
         match task {
             Task::AcceptConnection(handle) => handle,
+            Task::Bootstrap(handle) => handle,
             Task::ReceiveDownstream(handle) => handle,
             Task::SendDownstream(handle) => handle,
             Task::Notify(handle) => handle,


### PR DESCRIPTION
…sions

Track the late bootstrap path for notify and share-monitor setup inside the task manager and mark downstreams closed before teardown so a disconnect cannot race with deferred initialization and recreate stats or long-lived tasks for a dead miner.