### PR TITLE
FIX keep channel hashrate accounting single-owner during downstream c…

### DIFF
--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -68,12 +68,17 @@ impl Downstream {
     pub fn remove_downstream_hashrate_from_channel(
         self_: &Arc<Mutex<Self>>,
     ) -> ProxyResult<'static, ()> {
-        let (upstream_diff, estimated_downstream_hash_rate) = self_.safe_lock(|d| {
-            (
-                d.upstream_difficulty_config.clone(),
-                d.difficulty_mgmt.estimated_downstream_hash_rate,
-            )
-        })?;
+        let (upstream_diff, estimated_downstream_hash_rate, should_subtract) =
+            self_.safe_lock(|d| {
+                (
+                    d.upstream_difficulty_config.clone(),
+                    d.difficulty_mgmt.estimated_downstream_hash_rate,
+                    d.take_channel_hashrate_registered(),
+                )
+            })?;
+        if !should_subtract {
+            return Ok(());
+        }
         info!(
             "Removing downstream hashrate from channel upstream_diff: {:?}, downstream_diff: {:?}",
             upstream_diff, estimated_downstream_hash_rate

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -128,6 +128,7 @@ pub struct Downstream {
     tx_update_token: Sender<String>,
     pub session_timing: std::cell::RefCell<DownstreamSessionTiming>,
     submit_counts_for_diff: Cell<bool>,
+    channel_hashrate_registered: Cell<bool>,
     closed: Cell<bool>,
 }
 
@@ -220,6 +221,7 @@ impl Downstream {
             tx_update_token,
             session_timing: std::cell::RefCell::new(DownstreamSessionTiming::new(accepted_at)),
             submit_counts_for_diff: Cell::new(false),
+            channel_hashrate_registered: Cell::new(false),
             closed: Cell::new(false),
         }));
 
@@ -584,6 +586,7 @@ impl Downstream {
                 std::time::Instant::now(),
             )),
             submit_counts_for_diff: Cell::new(false),
+            channel_hashrate_registered: Cell::new(false),
             closed: Cell::new(false),
         }
     }
@@ -594,6 +597,14 @@ impl Downstream {
 
     pub(super) fn take_submit_diff_count_flag(&self) -> bool {
         self.submit_counts_for_diff.replace(false)
+    }
+
+    pub(super) fn mark_channel_hashrate_registered(&self) {
+        self.channel_hashrate_registered.set(true);
+    }
+
+    pub(super) fn take_channel_hashrate_registered(&self) -> bool {
+        self.channel_hashrate_registered.replace(false)
     }
 
     pub(super) fn mark_closed(&self) {

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -48,6 +48,7 @@ pub async fn start_notify(
             })?;
         upstream_difficulty_config
             .safe_lock(|c| c.channel_nominal_hashrate += Configuration::downstream_hashrate())?;
+        downstream.safe_lock(|d| d.mark_channel_hashrate_registered())?;
         if let Err(e) = stats_sender.setup_stats_reliable(connection_id).await {
             error!("Failed to register downstream stats {connection_id}: {e}");
         }
@@ -57,12 +58,15 @@ pub async fn start_notify(
             if let Err(e) = stats_sender.remove_stats_reliable(connection_id).await {
                 error!("Failed to rollback downstream stats {connection_id}: {e}");
             }
-            upstream_difficulty_config.safe_lock(|u| {
-                u.channel_nominal_hashrate -= f32::min(
-                    Configuration::downstream_hashrate(),
-                    u.channel_nominal_hashrate,
-                );
-            })?;
+            let should_subtract = downstream.safe_lock(|d| d.take_channel_hashrate_registered())?;
+            if should_subtract {
+                upstream_difficulty_config.safe_lock(|u| {
+                    u.channel_nominal_hashrate -= f32::min(
+                        Configuration::downstream_hashrate(),
+                        u.channel_nominal_hashrate,
+                    );
+                })?;
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
…leanup

Track whether a downstream has actually registered its nominal hashrate in the shared upstream channel state and consume that marker on cleanup so rollback and normal disconnect paths cannot both subtract the same miner.

This prevents bootstrap races from removing aggregate hashrate twice and skewing later difficulty decisions for other active downstreams.