### PR TITLE
FIX downstream difficulty floor outside local mode to keep remote min…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmnd-client"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 
 [lib]

--- a/src/translator/downstream/accept_connection.rs
+++ b/src/translator/downstream/accept_connection.rs
@@ -41,19 +41,21 @@ pub async fn start_accept_connection(
             // These values are global startup inputs, not per-miner properties.
             let initial_hash_rate = Configuration::downstream_hashrate();
             let share_per_second = *crate::SHARE_PER_MIN / 60.0;
-            let initial_difficulty = initial_hash_rate / (share_per_second * 2f32.powf(32.0));
-            let initial_difficulty =
+            let base_initial_difficulty = initial_hash_rate / (share_per_second * 2f32.powf(32.0));
+            let base_initial_difficulty =
                 crate::translator::downstream::diff_management::nearest_power_of_10(
-                    initial_difficulty,
+                    base_initial_difficulty,
                 );
-            let expected_hash_rate = share_per_second * initial_difficulty * 2f32.powf(32.0);
+            let hard_minimum_difficulty =
+                crate::translator::downstream::diff_management::hard_minimum_difficulty_for_proxy_mode(
+                    Configuration::local(),
+                );
 
             debug!(
-                "Translator downstream startup params: hash_rate={} H/s, shares_per_second={}, initial_difficulty={}, expected_hash_rate={} H/s",
+                "Translator downstream startup params: hash_rate={} H/s, shares_per_second={}, base_initial_difficulty={}",
                 initial_hash_rate,
                 share_per_second,
-                initial_difficulty,
-                expected_hash_rate
+                base_initial_difficulty,
             );
 
             match Bridge::ready(&bridge).await {
@@ -73,7 +75,19 @@ pub async fn start_accept_connection(
                     address: addr,
                     accepted_at,
                 } = connection;
+                let initial_difficulty =
+                    crate::translator::downstream::diff_management::clamp_downstream_difficulty_to_floor(
+                        base_initial_difficulty,
+                        hard_minimum_difficulty,
+                    );
+                let expected_hash_rate = share_per_second * initial_difficulty * 2f32.powf(32.0);
                 debug!("Translator opening connection for ip {}", addr);
+                if initial_difficulty != base_initial_difficulty {
+                    debug!(
+                        "Translator clamped downstream {} initial difficulty from {} to {}",
+                        addr, base_initial_difficulty, initial_difficulty
+                    );
+                }
                 record_stage(SessionTimingStage::AcceptQueueWait, accepted_at.elapsed());
                 let bridge_open_started_at = std::time::Instant::now();
                 let open_sv1_downstream =
@@ -126,6 +140,7 @@ pub async fn start_accept_connection(
                                 recv,
                                 task_manager,
                                 initial_difficulty,
+                                hard_minimum_difficulty,
                                 stats_sender,
                                 tx_update_token,
                                 accepted_at,

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -13,6 +13,8 @@ use sv1_api::json_rpc;
 
 use tracing::{error, info};
 
+pub const NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY: f32 = 100_000.0;
+
 impl Downstream {
     /// Initializes difficult managment.
     /// Send downstream a first target.
@@ -227,20 +229,25 @@ impl Downstream {
             return Err(Error::Unrecoverable);
         }
 
-        let (mut pid, latest_difficulty, initial_difficulty) = self_.safe_lock(|d| {
-            (
-                d.difficulty_mgmt.pid_controller,
-                d.difficulty_mgmt
-                    .current_difficulties
-                    .back()
-                    .copied()
-                    .unwrap_or(d.difficulty_mgmt.initial_difficulty),
-                d.difficulty_mgmt.initial_difficulty,
-            )
-        })?;
+        let (mut pid, latest_difficulty, initial_difficulty, hard_minimum_difficulty) = self_
+            .safe_lock(|d| {
+                (
+                    d.difficulty_mgmt.pid_controller,
+                    d.difficulty_mgmt
+                        .current_difficulties
+                        .back()
+                        .copied()
+                        .unwrap_or(d.difficulty_mgmt.initial_difficulty),
+                    d.difficulty_mgmt.initial_difficulty,
+                    d.difficulty_mgmt.hard_minimum_difficulty,
+                )
+            })?;
 
         let pid_output = pid.next_control_output(realized_share_per_min).output;
-        let new_difficulty = (latest_difficulty + pid_output).max(initial_difficulty * 0.1);
+        let new_difficulty = clamp_downstream_difficulty_to_floor(
+            (latest_difficulty + pid_output).max(initial_difficulty * 0.1),
+            hard_minimum_difficulty,
+        );
         let nearest = nearest_power_of_10(new_difficulty);
         if nearest != initial_difficulty {
             let mut pid: Pid<f32> = Pid::new(*crate::SHARE_PER_MIN, nearest * 10.0);
@@ -330,9 +337,28 @@ pub fn nearest_power_of_10(x: f32) -> f32 {
     10f32.powi(exponent)
 }
 
+pub fn hard_minimum_difficulty_for_proxy_mode(local_mode: bool) -> Option<f32> {
+    if local_mode {
+        None
+    } else {
+        Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY)
+    }
+}
+
+pub fn clamp_downstream_difficulty_to_floor(
+    difficulty: f32,
+    hard_minimum_difficulty: Option<f32>,
+) -> f32 {
+    hard_minimum_difficulty.map_or(difficulty, |minimum| difficulty.max(minimum))
+}
+
 #[cfg(test)]
 mod test {
     use super::super::super::upstream::diff_management::UpstreamDifficultyConfig;
+    use super::{
+        clamp_downstream_difficulty_to_floor, hard_minimum_difficulty_for_proxy_mode,
+        NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY,
+    };
     use crate::translator::downstream::{downstream::DownstreamDifficultyConfig, Downstream};
     use binary_sv2::U256;
     use pid::Pid;
@@ -440,6 +466,80 @@ mod test {
         crate::translator::downstream::diff_management::nearest_power_of_10(initial_difficulty)
     }
 
+    #[test]
+    fn non_local_proxy_mode_floor_is_100k() {
+        assert_eq!(
+            hard_minimum_difficulty_for_proxy_mode(false),
+            Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY)
+        );
+        assert_eq!(
+            clamp_downstream_difficulty_to_floor(
+                10_000.0,
+                Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY)
+            ),
+            NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY
+        );
+        assert_eq!(
+            clamp_downstream_difficulty_to_floor(
+                1_000_000.0,
+                Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY)
+            ),
+            1_000_000.0
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_downstream_retarget_respects_hard_floor() {
+        let mut diff = VecDeque::new();
+        diff.push_back(10_000.0);
+        let downstream_conf = DownstreamDifficultyConfig {
+            estimated_downstream_hash_rate: 0.0,
+            pid_controller: Pid::new(10.0, 100_000.0),
+            current_difficulties: diff,
+            submits: VecDeque::new(),
+            initial_difficulty: 10_000.0,
+            hard_minimum_difficulty: Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY),
+        };
+        let upstream_config = UpstreamDifficultyConfig {
+            channel_diff_update_interval: 60,
+            channel_nominal_hashrate: 0.0,
+        };
+        let (tx_sv1_submit, _rx_sv1_submit) = tokio::sync::mpsc::channel(10);
+        let (tx_outgoing, _rx_outgoing) = channel(10);
+        let (tx_update_token, _rx_update_token) = channel(10);
+        let random_str = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+        let first_job = Notify {
+            job_id: "ciao".to_string(),
+            prev_hash: PrevHash::try_from("0".repeat(64).as_str()).unwrap(),
+            coin_base1: "ffff".try_into().unwrap(),
+            coin_base2: "ffff".try_into().unwrap(),
+            merkle_branch: vec![MerkleNode::try_from(random_str).unwrap()],
+            version: HexU32Be(5667),
+            bits: HexU32Be(5678),
+            time: HexU32Be(5609),
+            clean_jobs: true,
+        };
+        let downstream = Arc::new(Mutex::new(Downstream::new(
+            1,
+            vec![],
+            vec![],
+            None,
+            None,
+            tx_sv1_submit,
+            tx_outgoing,
+            0,
+            downstream_conf,
+            Arc::new(Mutex::new(upstream_config)),
+            crate::api::stats::StatsSender::new(),
+            first_job,
+            tx_update_token,
+        )));
+
+        let updated = Downstream::update_difficulty_and_hashrate(&downstream).unwrap();
+
+        assert_eq!(updated, Some(NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY));
+    }
+
     #[tokio::test]
     async fn test_converge_to_spm_from_low() {
         test_converge_to_spm(1.0).await
@@ -460,6 +560,7 @@ mod test {
             current_difficulties: diff,
             submits: VecDeque::new(),
             initial_difficulty: 10_000_000_000.0,
+            hard_minimum_difficulty: None,
         };
         let upstream_config = UpstreamDifficultyConfig {
             channel_diff_update_interval: 60,

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -53,6 +53,7 @@ pub struct DownstreamDifficultyConfig {
     pub pid_controller: Pid<f32>,
     pub current_difficulties: VecDeque<f32>,
     pub initial_difficulty: f32,
+    pub hard_minimum_difficulty: Option<f32>,
 }
 
 impl DownstreamDifficultyConfig {
@@ -148,6 +149,7 @@ impl Downstream {
         recv_from_down: Receiver<String>,
         task_manager: Arc<Mutex<TaskManager>>,
         initial_difficulty: f32,
+        hard_minimum_difficulty: Option<f32>,
         stats_sender: StatsSender,
         tx_update_token: Sender<String>,
         accepted_at: std::time::Instant,
@@ -194,6 +196,7 @@ impl Downstream {
             pid_controller: pid,
             current_difficulties,
             initial_difficulty,
+            hard_minimum_difficulty,
         };
 
         let token = Arc::new(Mutex::new(
@@ -1099,6 +1102,7 @@ mod tests {
             pid_controller: Pid::new(*crate::SHARE_PER_MIN, 10.0),
             current_difficulties,
             initial_difficulty: 1.0,
+            hard_minimum_difficulty: None,
         };
         let upstream_config = UpstreamDifficultyConfig {
             channel_diff_update_interval: crate::CHANNEL_DIFF_UPDTATE_INTERVAL,

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -265,6 +265,7 @@ mod tests {
             pid_controller: Pid::new(*crate::SHARE_PER_MIN, 10.0),
             current_difficulties,
             initial_difficulty: 1.0,
+            hard_minimum_difficulty: None,
         };
         let upstream_config = UpstreamDifficultyConfig {
             channel_diff_update_interval: crate::CHANNEL_DIFF_UPDTATE_INTERVAL,


### PR DESCRIPTION
…ers at 100000 minimum"

Apply the 100000 downstream floor whenever the proxy is not started with --local.

Enforce the same lower bound both when a downstream connects and when PID retargeting lowers difficulty so non-local deployments do not drift below the intended minimum.

Store the floor in downstream difficulty state and cover the behavior with focused tests."