### PR TITLE
FIX share accounting by binding issued-job difficulty and settling upstream submits separately

### DIFF
--- a/src/monitor/shares.rs
+++ b/src/monitor/shares.rs
@@ -136,12 +136,14 @@ impl SharesMonitor {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum RejectionReason {
     JobIdNotFound,
     InvalidShare,
     InvalidJobIdFormat,
     DifficultyMismatch,
+    UpstreamRejected,
+    RateLimited,
 }
 
 impl std::fmt::Display for RejectionReason {
@@ -151,6 +153,8 @@ impl std::fmt::Display for RejectionReason {
             RejectionReason::InvalidShare => write!(f, "Invalid share"),
             RejectionReason::InvalidJobIdFormat => write!(f, "Invalid job ID format"),
             RejectionReason::DifficultyMismatch => write!(f, "Difficulty mismatch"),
+            RejectionReason::UpstreamRejected => write!(f, "Upstream rejected share"),
+            RejectionReason::RateLimited => write!(f, "Share rate limited"),
         }
     }
 }

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -133,7 +133,7 @@ impl Downstream {
 
         // Get the last notify
         let recent_notify = self_
-            .safe_lock(|d| d.recent_jobs.clone_last())
+            .safe_lock(|d| d.recent_jobs.clone_last(new_diff as f32))
             .map_err(|_| Error::TranslatorDiffConfigMutexPoisoned)?;
 
         if let Some(notify) = recent_notify {

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -24,7 +24,8 @@ use tokio::sync::{
 use super::{
     accept_connection::start_accept_connection, notify::start_notify,
     receive_from_downstream::start_receive_downstream,
-    send_to_downstream::start_send_to_downstream, DownstreamMessages, SubmitShareWithChannelId,
+    send_to_downstream::start_send_to_downstream, DownstreamMessages, SubmitShareResultReceiver,
+    SubmitShareWithChannelId,
 };
 
 use roles_logic_sv2::{
@@ -377,6 +378,39 @@ impl Downstream {
         self_: Arc<Mutex<Self>>,
         message_sv1: json_rpc::Message,
     ) -> Result<(), super::super::error::Error<'static>> {
+        if let json_rpc::Message::StandardRequest(request) = &message_sv1 {
+            if request.method == "mining.submit" {
+                let submit = match client_to_server::Submit::try_from(request.clone()) {
+                    Ok(submit) => submit,
+                    Err(_) => {
+                        Self::reject_invalid_submit(self_, &message_sv1).await?;
+                        return Ok(());
+                    }
+                };
+
+                let is_valid_submission = self_.safe_lock(|s| {
+                    let has_valid_version_bits = match &submit.version_bits {
+                        Some(version_bits) => s
+                            .version_rolling_mask()
+                            .map(|mask| mask.check_mask(version_bits))
+                            .unwrap_or(false),
+                        None => s.version_rolling_mask().is_none(),
+                    };
+
+                    s.is_authorized(&submit.user_name)
+                        && s.extranonce2_size() == submit.extra_nonce2.len()
+                        && has_valid_version_bits
+                })?;
+
+                if !is_valid_submission {
+                    Self::reject_invalid_submit(self_, &message_sv1).await?;
+                    return Ok(());
+                }
+
+                return Self::handle_submit_request(self_, submit).await;
+            }
+        }
+
         // `handle_message` in `IsServer` trait + calls `handle_request`
         // TODO: Map err from V1Error to Error::V1Error
 
@@ -399,18 +433,8 @@ impl Downstream {
             }
             Err(e) => {
                 if matches!(e, sv1_api::error::Error::InvalidSubmission) {
-                    if let Some(response) = Self::invalid_submit_rejection(&message_sv1) {
-                        let (connection_id, reason) = self_.safe_lock(|s| {
-                            s.stats_sender.update_rejected_shares(s.connection_id);
-                            (s.connection_id, s.invalid_submit_reason(&message_sv1))
-                        })?;
-                        error!(
-                            "Downstream {}: rejected invalid mining.submit without disconnecting downstream: {}",
-                            connection_id, reason
-                        );
-                        Self::send_message_downstream(self_, response).await;
-                        return Ok(());
-                    }
+                    Self::reject_invalid_submit(self_, &message_sv1).await?;
+                    return Ok(());
                 }
                 error!("{e}");
                 Err(Error::V1Protocol(Box::new(e)))
@@ -489,6 +513,212 @@ impl Downstream {
         }
     }
 
+    pub(super) fn current_difficulty(&self) -> f32 {
+        self.difficulty_mgmt
+            .current_difficulties
+            .back()
+            .copied()
+            .unwrap_or(self.difficulty_mgmt.initial_difficulty)
+    }
+
+    async fn reject_invalid_submit(
+        self_: Arc<Mutex<Self>>,
+        message_sv1: &json_rpc::Message,
+    ) -> Result<(), Error<'static>> {
+        if let Some(response) = Self::invalid_submit_rejection(message_sv1) {
+            let (connection_id, reason) = self_.safe_lock(|s| {
+                s.stats_sender.update_rejected_shares(s.connection_id);
+                (s.connection_id, s.invalid_submit_reason(message_sv1))
+            })?;
+            error!(
+                "Downstream {}: rejected invalid mining.submit without disconnecting downstream: {}",
+                connection_id, reason
+            );
+            Self::send_message_downstream(self_, response).await;
+        }
+        Ok(())
+    }
+
+    fn spawn_submit_accounting(
+        self_: Arc<Mutex<Self>>,
+        response_rx: SubmitShareResultReceiver,
+        worker_name: String,
+        difficulty: f32,
+        job_id: i64,
+        nonce: i64,
+        request_job_id: String,
+    ) {
+        tokio::spawn(async move {
+            let submit_result = match response_rx.await {
+                Ok(result) => result,
+                Err(_) => Err(RejectionReason::UpstreamRejected),
+            };
+
+            let accounting_result = self_.safe_lock(|s| match submit_result {
+                Ok(()) => {
+                    let share =
+                        ShareInfo::new(worker_name.clone(), Some(difficulty), job_id, nonce, None);
+                    s.share_monitor.insert_share(share);
+                    s.stats_sender.update_accepted_shares(s.connection_id);
+                    if share_log_enabled() {
+                        info!(
+                            "Share for Job {} and difficulty {} is accepted upstream",
+                            request_job_id, difficulty
+                        );
+                    }
+                }
+                Err(reason) => {
+                    let share =
+                        ShareInfo::new(worker_name.clone(), None, job_id, nonce, Some(reason));
+                    s.share_monitor.insert_share(share);
+                    s.stats_sender.update_rejected_shares(s.connection_id);
+                    if share_log_enabled() {
+                        info!(
+                            "Share for Job {} and difficulty {} was rejected with {:?}",
+                            request_job_id, difficulty, reason
+                        );
+                    }
+                }
+            });
+
+            if let Err(e) = accounting_result {
+                error!("Failed to finalize submit accounting: {e}");
+                ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+            }
+        });
+    }
+
+    async fn handle_submit_request(
+        self_: Arc<Mutex<Self>>,
+        request: client_to_server::Submit<'static>,
+    ) -> Result<(), Error<'static>> {
+        if share_log_enabled() {
+            info!(
+                "Handling mining.submit request {} from {} with job_id {}, nonce: {:?}",
+                request.id, request.user_name, request.job_id, request.nonce
+            );
+        }
+
+        let job_id_as_number = match request.job_id.parse::<u32>() {
+            Ok(job_id) => job_id,
+            Err(_) => {
+                error!(
+                    "Share rejected: can not convert v1 job id to number. v1 id: {}",
+                    request.job_id
+                );
+                let nonce = request.nonce.0 as i64;
+                let share = ShareInfo::new(
+                    request.user_name.clone(),
+                    None,
+                    0,
+                    nonce,
+                    Some(RejectionReason::InvalidJobIdFormat),
+                );
+                self_.safe_lock(|s| {
+                    s.share_monitor.insert_share(share);
+                    s.stats_sender.update_rejected_shares(s.connection_id);
+                })?;
+                Self::send_message_downstream(self_, request.respond(false).into()).await;
+                return Ok(());
+            }
+        };
+
+        let job_id = job_id_as_number as i64;
+        let nonce = request.nonce.0 as i64;
+        let connection_id = self_.safe_lock(|s| s.connection_id)?;
+        crate::translator::utils::update_share_count(connection_id);
+
+        let (job, extranonce1, version_rolling_mask) = self_.safe_lock(|s| {
+            (
+                s.recent_jobs.get_matching_job(job_id_as_number),
+                s.extranonce1.clone(),
+                s.version_rolling_mask.clone(),
+            )
+        })?;
+
+        let job = match job {
+            Some(job) => job,
+            None => {
+                let share = ShareInfo::new(
+                    request.user_name.clone(),
+                    None,
+                    job_id,
+                    nonce,
+                    Some(RejectionReason::JobIdNotFound),
+                );
+                self_.safe_lock(|s| {
+                    s.share_monitor.insert_share(share);
+                    s.stats_sender.update_rejected_shares(s.connection_id);
+                })?;
+                error!(
+                    "Share rejected: can not find job with id {}",
+                    request.job_id
+                );
+                Self::send_message_downstream(self_, request.respond(false).into()).await;
+                return Ok(());
+            }
+        };
+
+        let mut upstream_request = request.clone();
+        upstream_request.job_id = job.notify.job_id.clone();
+
+        if !validate_share(
+            &upstream_request,
+            &job.notify,
+            job.difficulty,
+            extranonce1,
+            version_rolling_mask,
+        ) {
+            let share = ShareInfo::new(
+                request.user_name.clone(),
+                None,
+                job_id,
+                nonce,
+                Some(RejectionReason::InvalidShare),
+            );
+            self_.safe_lock(|s| {
+                s.share_monitor.insert_share(share);
+                s.stats_sender.update_rejected_shares(s.connection_id);
+            })?;
+            error!("Share rejected: Invalid share for stored job");
+            Self::send_message_downstream(self_, request.respond(false).into()).await;
+            return Ok(());
+        }
+
+        match Self::forward_submit_share(&self_, upstream_request).await {
+            Ok(response_rx) => {
+                Self::spawn_submit_accounting(
+                    self_.clone(),
+                    response_rx,
+                    request.user_name.clone(),
+                    job.difficulty,
+                    job_id,
+                    nonce,
+                    request.job_id.clone(),
+                );
+                self_.safe_lock(|s| s.submit_counts_for_diff.set(true))?;
+                Self::send_message_downstream(self_, request.respond(true).into()).await;
+            }
+            Err(e) => {
+                error!("Failed to forward downstream submit: {e}");
+                let share = ShareInfo::new(
+                    request.user_name.clone(),
+                    None,
+                    job_id,
+                    nonce,
+                    Some(RejectionReason::UpstreamRejected),
+                );
+                self_.safe_lock(|s| {
+                    s.share_monitor.insert_share(share);
+                    s.stats_sender.update_rejected_shares(s.connection_id);
+                })?;
+                Self::send_message_downstream(self_, request.respond(false).into()).await;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Send SV1 response message that is generated by `Downstream` (as opposed to being received
     /// by `Bridge`) to be written to the SV1 Downstream role.
     pub(super) async fn send_message_downstream(
@@ -525,25 +755,36 @@ impl Downstream {
         }
     }
 
-    fn forward_submit_share(&self, request: client_to_server::Submit<'static>) -> bool {
+    async fn forward_submit_share(
+        self_: &Arc<Mutex<Self>>,
+        request: client_to_server::Submit<'static>,
+    ) -> Result<SubmitShareResultReceiver, Error<'static>> {
+        let (channel_id, extranonce, extranonce2_len, version_rolling_mask, sender) = self_
+            .safe_lock(|s| {
+                (
+                    s.connection_id,
+                    s.extranonce1.clone(),
+                    s.extranonce2_len,
+                    s.version_rolling_mask.clone(),
+                    s.tx_sv1_bridge.clone(),
+                )
+            })?;
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let to_send = SubmitShareWithChannelId {
-            channel_id: self.connection_id,
+            channel_id,
             share: request,
-            extranonce: self.extranonce1.clone(),
-            extranonce2_len: self.extranonce2_len,
-            version_rolling_mask: self.version_rolling_mask.clone(),
+            extranonce,
+            extranonce2_len,
+            version_rolling_mask,
+            result_tx,
         };
 
-        if let Err(e) = self
-            .tx_sv1_bridge
-            .try_send(DownstreamMessages::SubmitShares(to_send))
-        {
-            error!("Failed to forward downstream submit: {e:?}");
-            self.stats_sender.update_rejected_shares(self.connection_id);
-            return false;
-        }
+        sender
+            .send(DownstreamMessages::SubmitShares(to_send))
+            .await
+            .map_err(|_| Error::AsyncChannelError)?;
 
-        true
+        Ok(result_rx)
     }
 
     #[cfg(test)]
@@ -634,8 +875,11 @@ impl IsServer<'static> for Downstream {
         self.version_rolling_mask = Some(version_rolling_mask.clone());
         self.version_rolling_min_bit = Some(version_rolling_min_bit_count.clone());
         let mut first_job = self.first_job.clone();
-        self.recent_jobs
-            .add_job(&mut first_job, self.version_rolling_mask.clone());
+        self.recent_jobs.add_job(
+            &mut first_job,
+            self.version_rolling_mask.clone(),
+            self.current_difficulty(),
+        );
         self.first_job = first_job;
 
         (
@@ -722,124 +966,9 @@ impl IsServer<'static> for Downstream {
 
     /// When miner find the job which meets requested difficulty, it can submit share to the server.
     /// Only [Submit](client_to_server::Submit) requests for authorized user names can be submitted.
-    fn handle_submit(&self, request: &client_to_server::Submit<'static>) -> bool {
-        if share_log_enabled() {
-            info!(
-                "Handling mining.submit request {} from {} with job_id {}, nonce: {:?}",
-                request.id, request.user_name, request.job_id, request.nonce
-            );
-        }
-
-        let mut request = request.clone();
-        let job_id_as_number = request.job_id.parse::<u32>();
-        let nonce = request.nonce.0 as i64;
-        if job_id_as_number.is_err() {
-            error!(
-                "Share rejected: can not convert v1 job id to number. v1 id: {}",
-                request.job_id
-            );
-
-            let share = ShareInfo::new(
-                request.user_name.clone(),
-                None,
-                0,
-                nonce,
-                // We can use this here beacuse we are inside the error branch
-                //
-                // TODO: Think about a better way to handle job id when it can not be parsed to
-                // number
-                // job_id_as_number.expect("checked above") as i64,
-                Some(RejectionReason::InvalidJobIdFormat),
-            );
-            self.share_monitor.insert_share(share);
-
-            self.stats_sender.update_rejected_shares(self.connection_id);
-            return false;
-        }
-        let job_id = job_id_as_number.clone().expect("checked above") as i64;
-        crate::translator::utils::update_share_count(self.connection_id); // update share count
-        if let Some(job) = self
-            .recent_jobs
-            .get_matching_job(job_id_as_number.expect("checked above"))
-        {
-            request.job_id = job.job_id.clone();
-
-            // Shares must always be validated locally. Disabling difficulty updates only
-            // disables downstream/internal retargeting, not share validation itself.
-            if let Some(met_difficulty) = validate_share(
-                &request,
-                &job,
-                &self.difficulty_mgmt.current_difficulties,
-                self.extranonce1.clone(),
-                self.version_rolling_mask.clone(),
-            ) {
-                // Only forward upstream if the share meets the latest difficulty
-                if let Some(latest_difficulty) = self.difficulty_mgmt.current_difficulties.back() {
-                    if met_difficulty == *latest_difficulty {
-                        if !self.forward_submit_share(request.clone()) {
-                            return false;
-                        }
-
-                        // Share is accepted here
-                        let share = ShareInfo::new(
-                            request.user_name.clone(),
-                            Some(met_difficulty),
-                            job_id,
-                            nonce,
-                            None,
-                        );
-                        self.share_monitor.insert_share(share);
-                        self.submit_counts_for_diff.set(true);
-                        self.stats_sender.update_accepted_shares(self.connection_id);
-                    } else {
-                        // met_difficulty is not latest difficulty, so we mark it as rejected
-                        let share = ShareInfo::new(
-                            request.user_name.clone(),
-                            None,
-                            job_id, // rejected because it was not sent upstream
-                            nonce,
-                            Some(RejectionReason::DifficultyMismatch),
-                        );
-                        self.share_monitor.insert_share(share);
-                        self.stats_sender.update_rejected_shares(self.connection_id);
-                    }
-                }
-                if share_log_enabled() {
-                    info!(
-                        "Share for Job {} and difficulty {} is accepted",
-                        request.job_id, met_difficulty
-                    );
-                }
-                true
-            } else {
-                let share = ShareInfo::new(
-                    request.user_name.clone(),
-                    None,
-                    job_id,
-                    nonce,
-                    Some(RejectionReason::InvalidShare),
-                );
-                self.share_monitor.insert_share(share);
-                error!("Share rejected: Invalid share");
-                self.stats_sender.update_rejected_shares(self.connection_id);
-                false
-            }
-        } else {
-            let event = ShareInfo::new(
-                request.user_name.clone(),
-                None,
-                job_id,
-                nonce,
-                Some(RejectionReason::JobIdNotFound),
-            );
-            self.share_monitor.insert_share(event);
-            error!(
-                "Share rejected: can not find job with id {}",
-                request.job_id
-            );
-            self.stats_sender.update_rejected_shares(self.connection_id);
-            false
-        }
+    fn handle_submit(&self, _request: &client_to_server::Submit<'static>) -> bool {
+        error!("Downstream::handle_submit should not be called directly");
+        false
     }
 
     /// Indicates to the server that the client supports the mining.set_extranonce method.
@@ -912,10 +1041,17 @@ impl IsDownstream for Downstream {
 
 const TRACKED_RECENT_JOBS: usize = 3;
 
+#[derive(Debug, Clone)]
+pub(crate) struct IssuedJob {
+    pub notify: Notify<'static>,
+    pub difficulty: f32,
+}
+
 #[derive(Debug)]
 pub struct RecentJobs {
     v1_to_v2: HashMap<u32, u32>,
     v2_to_v1: HashMap<u32, Vec<u32>>,
+    issued_jobs: HashMap<u32, IssuedJob>,
     jobs: VecDeque<Notify<'static>>,
     last_v2s: CircularBuffer<u32, TRACKED_RECENT_JOBS>,
     tracked_jobs: usize,
@@ -926,11 +1062,20 @@ fn apply_mask(mask: Option<HexU32Be>, message: &mut server_to_client::Notify<'st
     }
 }
 impl RecentJobs {
-    pub fn add_job(&mut self, notify: &mut Notify<'static>, mask: Option<HexU32Be>) {
+    pub(crate) fn add_job(
+        &mut self,
+        notify: &mut Notify<'static>,
+        mask: Option<HexU32Be>,
+        difficulty: f32,
+    ) {
         apply_mask(mask, notify);
         // save it with the v2 id
         self.jobs.push_back(notify.clone());
-        let new_id = self.new_v1(notify.job_id.parse::<u32>().unwrap());
+        let new_id = self.new_v1(
+            notify.job_id.parse::<u32>().unwrap(),
+            notify.clone(),
+            difficulty,
+        );
         // send it with the v1 id
         notify.job_id = new_id.to_string();
         if self.jobs.len() > self.tracked_jobs {
@@ -938,10 +1083,10 @@ impl RecentJobs {
         };
     }
 
-    pub fn clone_last(&mut self) -> Option<Notify<'static>> {
+    pub(crate) fn clone_last(&mut self, difficulty: f32) -> Option<Notify<'static>> {
         if let Some(job) = self.jobs.back() {
             let mut job = job.clone();
-            let new_id = self.new_v1(job.job_id.parse::<u32>().unwrap());
+            let new_id = self.new_v1(job.job_id.parse::<u32>().unwrap(), job.clone(), difficulty);
             job.job_id = new_id.to_string();
             Some(job.clone())
         } else {
@@ -949,19 +1094,15 @@ impl RecentJobs {
         }
     }
 
-    pub fn current_jobs(&self) -> VecDeque<Notify<'static>> {
+    pub(crate) fn current_jobs(&self) -> VecDeque<Notify<'static>> {
         self.jobs.clone()
     }
 
-    pub fn get_matching_job(&self, v1_id: u32) -> Option<Notify<'static>> {
-        let v2_id = self.get_v2(v1_id)?;
-        self.current_jobs()
-            .iter()
-            .find(|notify| notify.job_id == v2_id)
-            .cloned()
+    pub(crate) fn get_matching_job(&self, v1_id: u32) -> Option<IssuedJob> {
+        self.issued_jobs.get(&v1_id).cloned()
     }
 
-    fn new_v1(&mut self, v2_id: u32) -> u32 {
+    fn new_v1(&mut self, v2_id: u32, notify: Notify<'static>, difficulty: f32) -> u32 {
         let mut v1_id = rand::thread_rng().gen();
         while self.v1_to_v2.contains_key(&v1_id) {
             v1_id = rand::thread_rng().gen();
@@ -978,22 +1119,23 @@ impl RecentJobs {
             }
         }
         self.v1_to_v2.insert(v1_id, v2_id);
+        self.issued_jobs
+            .insert(v1_id, IssuedJob { notify, difficulty });
         v1_id
     }
     fn remove_v2(&mut self, v2_id: u32) {
         if let Some(v1_ids) = self.v2_to_v1.remove(&v2_id) {
             for v1_id in v1_ids {
                 self.v1_to_v2.remove(&v1_id);
+                self.issued_jobs.remove(&v1_id);
             }
         }
-    }
-    fn get_v2(&self, v1_id: u32) -> Option<String> {
-        self.v1_to_v2.get(&v1_id).cloned().map(|v| v.to_string())
     }
     pub fn new() -> Self {
         Self {
             v1_to_v2: HashMap::new(),
             v2_to_v1: HashMap::new(),
+            issued_jobs: HashMap::new(),
             last_v2s: CircularBuffer::new(),
             jobs: VecDeque::new(),
             tracked_jobs: TRACKED_RECENT_JOBS,
@@ -1325,5 +1467,56 @@ mod tests {
             reason,
             "invalid version_bits `00000002` for version-rolling mask `00000001`"
         );
+    }
+
+    #[test]
+    fn recent_jobs_bind_difficulty_to_each_issued_v1_job() {
+        let mut recent_jobs = RecentJobs::new();
+        let mut job = first_job("42");
+
+        recent_jobs.add_job(&mut job, None, 1.0);
+        let first_v1_id = job.job_id.parse::<u32>().unwrap();
+        let first_snapshot = recent_jobs.get_matching_job(first_v1_id).unwrap();
+        assert_eq!(first_snapshot.notify.job_id, "42");
+        assert_eq!(first_snapshot.difficulty, 1.0);
+
+        let reissued_job = recent_jobs.clone_last(2.0).unwrap();
+        let reissued_v1_id = reissued_job.job_id.parse::<u32>().unwrap();
+        let reissued_snapshot = recent_jobs.get_matching_job(reissued_v1_id).unwrap();
+        let original_snapshot = recent_jobs.get_matching_job(first_v1_id).unwrap();
+
+        assert_eq!(reissued_snapshot.notify.job_id, "42");
+        assert_eq!(reissued_snapshot.difficulty, 2.0);
+        assert_eq!(original_snapshot.difficulty, 1.0);
+    }
+
+    #[test]
+    fn recent_jobs_preserve_three_v2_job_retention() {
+        let mut recent_jobs = RecentJobs::new();
+
+        let mut job_1 = first_job("1");
+        recent_jobs.add_job(&mut job_1, None, 1.0);
+        let job_1_v1 = job_1.job_id.parse::<u32>().unwrap();
+        let job_1_reissued = recent_jobs.clone_last(2.0).unwrap();
+        let job_1_reissued_v1 = job_1_reissued.job_id.parse::<u32>().unwrap();
+
+        let mut job_2 = first_job("2");
+        recent_jobs.add_job(&mut job_2, None, 2.0);
+        let job_2_v1 = job_2.job_id.parse::<u32>().unwrap();
+
+        let mut job_3 = first_job("3");
+        recent_jobs.add_job(&mut job_3, None, 3.0);
+        let job_3_v1 = job_3.job_id.parse::<u32>().unwrap();
+
+        let mut job_4 = first_job("4");
+        recent_jobs.add_job(&mut job_4, None, 4.0);
+        let job_4_v1 = job_4.job_id.parse::<u32>().unwrap();
+
+        assert_eq!(recent_jobs.current_jobs().len(), 3);
+        assert!(recent_jobs.get_matching_job(job_1_v1).is_none());
+        assert!(recent_jobs.get_matching_job(job_1_reissued_v1).is_none());
+        assert!(recent_jobs.get_matching_job(job_2_v1).is_some());
+        assert!(recent_jobs.get_matching_job(job_3_v1).is_some());
+        assert!(recent_jobs.get_matching_job(job_4_v1).is_some());
     }
 }

--- a/src/translator/downstream/mod.rs
+++ b/src/translator/downstream/mod.rs
@@ -1,5 +1,9 @@
+use roles_logic_sv2::mining_sv2::SubmitSharesExtended;
 use roles_logic_sv2::mining_sv2::Target;
 use sv1_api::{client_to_server::Submit, utils::HexU32Be};
+use tokio::sync::oneshot;
+
+use crate::monitor::shares::RejectionReason;
 pub mod diff_management;
 #[allow(clippy::module_inception)]
 pub mod downstream;
@@ -18,15 +22,19 @@ mod task_manager;
 const SUBSCRIBE_TIMEOUT_SECS: u64 = 10;
 
 /// enum of messages sent to the Bridge
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum DownstreamMessages {
     SubmitShares(SubmitShareWithChannelId),
     SetDownstreamTarget(SetDownstreamTarget),
 }
 
+pub type SubmitShareResult = Result<(), RejectionReason>;
+pub type SubmitShareResultReceiver = oneshot::Receiver<SubmitShareResult>;
+pub type SubmitShareResultSender = oneshot::Sender<SubmitShareResult>;
+
 /// wrapper around a `mining.submit` with extra channel informationfor the Bridge to
 /// process
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SubmitShareWithChannelId {
     pub channel_id: u32,
     pub share: Submit<'static>,
@@ -36,6 +44,13 @@ pub struct SubmitShareWithChannelId {
     #[allow(dead_code)]
     extranonce2_len: usize,
     pub version_rolling_mask: Option<HexU32Be>,
+    pub result_tx: SubmitShareResultSender,
+}
+
+#[derive(Debug)]
+pub struct UpstreamSubmitShare {
+    pub share: SubmitSharesExtended<'static>,
+    pub result_tx: SubmitShareResultSender,
 }
 
 /// message for notifying the bridge that a downstream target has updated

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -13,14 +13,17 @@ use tokio::task;
 use tracing::{debug, error, warn};
 
 fn current_or_initial_job(downstream: &mut Downstream) -> server_to_client::Notify<'static> {
-    if let Some(job) = downstream.recent_jobs.clone_last() {
+    let difficulty = downstream.current_difficulty();
+    if let Some(job) = downstream.recent_jobs.clone_last(difficulty) {
         return job;
     }
 
     let mut first_job = downstream.first_job.clone();
-    downstream
-        .recent_jobs
-        .add_job(&mut first_job, downstream.version_rolling_mask.clone());
+    downstream.recent_jobs.add_job(
+        &mut first_job,
+        downstream.version_rolling_mask.clone(),
+        difficulty,
+    );
     first_job
 }
 
@@ -138,7 +141,9 @@ pub async fn start_notify(
                         .safe_lock(|d| {
                             d.first_job = sv1_mining_notify_msg.clone();
                             let mask = d.version_rolling_mask.clone();
-                            d.recent_jobs.add_job(&mut sv1_mining_notify_msg, mask);
+                            let difficulty = d.current_difficulty();
+                            d.recent_jobs
+                                .add_job(&mut sv1_mining_notify_msg, mask, difficulty);
                             debug!(
                                 "Downstream {}: Added job_id {} to recent_notifies. Current jobs: {:?}",
                                 connection_id,

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -18,7 +18,10 @@ use tokio::sync::broadcast;
 
 use super::{
     super::{
-        downstream::{DownstreamMessages, SetDownstreamTarget, SubmitShareWithChannelId},
+        downstream::{
+            DownstreamMessages, SetDownstreamTarget, SubmitShareResult, SubmitShareWithChannelId,
+            UpstreamSubmitShare,
+        },
         error::{Error, ProxyResult},
     },
     task_manager::TaskManager,
@@ -27,7 +30,7 @@ use crate::{
     proxy_state::{ProxyState, TranslatorState, UpstreamType},
     share_log_enabled,
     shared::utils::AbortOnDrop,
-    translator::utils::allow_submit_share,
+    translator::utils::{allow_submit_share, submit_error_to_rejection_reason},
 };
 use lazy_static::lazy_static;
 use roles_logic_sv2::{channel_logic::channel_factory::OnNewShare, Error as RolesLogicError};
@@ -45,7 +48,7 @@ lazy_static! {
 pub struct Bridge {
     /// Sends SV2 `SubmitSharesExtended` messages translated from SV1 `mining.submit` messages to
     /// the `Upstream`.
-    tx_sv2_submit_shares_ext: tokio::sync::mpsc::Sender<SubmitSharesExtended<'static>>,
+    tx_sv2_submit_shares_ext: tokio::sync::mpsc::Sender<UpstreamSubmitShare>,
     /// Sends SV1 `mining.notify` message (translated from the SV2 `SetNewPrevHash` and
     /// `NewExtendedMiningJob` messages stored in the `NextMiningNotify`) to the `Downstream`.
     tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
@@ -80,7 +83,7 @@ impl Bridge {
     #[allow(clippy::too_many_arguments)]
     /// Instantiate a new `Bridge`.
     pub fn new(
-        tx_sv2_submit_shares_ext: tokio::sync::mpsc::Sender<SubmitSharesExtended<'static>>,
+        tx_sv2_submit_shares_ext: tokio::sync::mpsc::Sender<UpstreamSubmitShare>,
         tx_sv1_notify: broadcast::Sender<server_to_client::Notify<'static>>,
         extranonces: ExtendedExtranonce,
         target: Arc<Mutex<Vec<u8>>>,
@@ -242,15 +245,28 @@ impl Bridge {
         Ok(())
     }
 
+    fn resolve_submit(
+        result_tx: tokio::sync::oneshot::Sender<SubmitShareResult>,
+        result: SubmitShareResult,
+    ) {
+        let _ = result_tx.send(result);
+    }
+
     /// receives a `SubmitShareWithChannelId` and validates the shares and sends to `Upstream` if
     /// the share meets the upstream target
     async fn handle_submit_shares(
         self_: Arc<Mutex<Self>>,
         share: SubmitShareWithChannelId,
     ) -> ProxyResult<'static, ()> {
-        let channel_id = share.channel_id;
-        let job_id = share.share.job_id.clone();
-        let share_id = share.share.id;
+        let SubmitShareWithChannelId {
+            channel_id,
+            share,
+            version_rolling_mask,
+            result_tx,
+            ..
+        } = share;
+        let job_id = share.job_id.clone();
+        let share_id = share.id;
         if share_log_enabled() {
             info!(
                 "Bridge received share {:?} for channel {:?} and job {:?}",
@@ -270,9 +286,9 @@ impl Bridge {
         dbg_target.reverse();
         debug!("Pool target: {:?}", dbg_target.as_hex());
         let mut upstream_target: Target = upstream_target.into();
-        let res = self_
+        let translated_share = match self_
             .safe_lock(|s| {
-                let job_id = share.share.job_id.parse::<u32>().expect("Invalid job_id");
+                let job_id = share.job_id.parse::<u32>().expect("Invalid job_id");
                 if s.channel_factory.job(job_id).is_none() {
                     warn!(
                         "Share rejected: job_id {} not in retained job cache",
@@ -281,23 +297,63 @@ impl Bridge {
                     return Err(roles_logic_sv2::Error::ShareDoNotMatchAnyJob); // rejected
                 }
                 s.channel_factory.set_target(&mut upstream_target);
-                match s.translate_submit(share.channel_id, share.share, share.version_rolling_mask)
-                {
-                    Ok(submit_shares_extended) => {
-                        // Ordering::Relaxed is safe here because we only need simple counter updates.
-                        // No need for strict ordering since it just tracks failures.
-                        SUBMIT_FAIL_COUNTER.store(0, Ordering::Relaxed); // Reset on success
-                        s.channel_factory
-                            .on_submit_shares_extended(submit_shares_extended)
-                    }
-                    Err(_) => {
-                        Err(roles_logic_sv2::Error::NoValidJob) // Error will be handled by the caller
-                    }
+                s.translate_submit(channel_id, share.clone(), version_rolling_mask.clone())
+                    .map_err(|_| roles_logic_sv2::Error::NoValidJob)
+            })
+            .map_err(|_| Error::BridgeMutexPoisoned)?
+        {
+            Ok(share) => share,
+            Err(roles_logic_sv2::Error::NoValidJob) => {
+                let count = SUBMIT_FAIL_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+                if count >= 10 {
+                    error!("Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message after 10 attempts");
+                    Self::resolve_submit(
+                        result_tx,
+                        Err(crate::monitor::shares::RejectionReason::JobIdNotFound),
+                    );
+                    return Err(Error::RolesSv2Logic(roles_logic_sv2::Error::NoValidJob));
                 }
+                warn!(
+                    "Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message, attempt {}",
+                    count
+                );
+                Self::resolve_submit(
+                    result_tx,
+                    Err(crate::monitor::shares::RejectionReason::JobIdNotFound),
+                );
+                return Ok(());
+            }
+            Err(roles_logic_sv2::Error::ShareDoNotMatchAnyJob) => {
+                warn!(
+                    "Channel factory can not get this share's job_id: {}",
+                    job_id
+                );
+                Self::resolve_submit(
+                    result_tx,
+                    Err(crate::monitor::shares::RejectionReason::JobIdNotFound),
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                Self::resolve_submit(
+                    result_tx,
+                    Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
+                );
+                return Err(Error::RolesSv2Logic(e));
+            }
+        };
+
+        let res = self_
+            .safe_lock(|s| {
+                // Ordering::Relaxed is safe here because we only need simple counter updates.
+                // No need for strict ordering since it just tracks failures.
+                SUBMIT_FAIL_COUNTER.store(0, Ordering::Relaxed);
+                s.channel_factory
+                    .on_submit_shares_extended(translated_share.clone())
             })
             .map_err(|_| Error::BridgeMutexPoisoned)?;
 
-        match res {
+        let upstream_share = match res {
             Ok(OnNewShare::SendErrorDownstream(e)) => {
                 let error_code = std::str::from_utf8(&e.error_code.to_vec()[..])
                     .unwrap_or("unparsable error code")
@@ -306,33 +362,23 @@ impl Bridge {
                     "Submit share {} from channel {} and job {} error {}",
                     &share_id, &channel_id, &job_id, error_code
                 );
+                Self::resolve_submit(
+                    result_tx,
+                    Err(submit_error_to_rejection_reason(&error_code)),
+                );
+                return Ok(());
             }
             Ok(OnNewShare::SendSubmitShareUpstream((s, _))) => {
-                if let Ok(is_rate_limited) = allow_submit_share() {
-                    if !is_rate_limited {
-                        warn!("Share will not be sent upstream: Exceeded 70 shares/min limit");
-                        return Ok(());
-                    }
-                    if share_log_enabled() {
-                        info!(
-                            "Share with id {} meets upstream target from channel {} and job {}",
-                            &share_id, &channel_id, &job_id
-                        );
-                    }
-                    match s {
-                        Share::Extended(share) => {
-                            if tx_sv2_submit_shares_ext.send(share).await.is_err() {
-                                error!("Failed to send SubmitShareExtended downstream");
-                                return Err(Error::AsyncChannelError);
-                            }
-                        }
-                        // We are in an extended channel shares are extended
-                        Share::Standard(_) => unreachable!(),
-                    }
-                } else {
-                    error!("Failed to record share: Bridge mutex poisoned");
-                    ProxyState::update_inconsistency(Some(1));
-                    return Err(Error::BridgeMutexPoisoned);
+                if share_log_enabled() {
+                    info!(
+                        "Share with id {} meets upstream target from channel {} and job {}",
+                        &share_id, &channel_id, &job_id
+                    );
+                }
+                match s {
+                    Share::Extended(share) => share,
+                    // We are in an extended channel shares are extended
+                    Share::Standard(_) => unreachable!(),
                 }
             }
             // We are in an extended channel this variant is group channle only
@@ -340,34 +386,55 @@ impl Bridge {
             Ok(OnNewShare::ShareMeetDownstreamTarget) => {
                 if share_log_enabled() {
                     info!(
-                        "Share with id {} meets downstream target from channel {} and job {}",
+                        "Share with id {} meets downstream target from channel {} and job {}; forwarding upstream for final acceptance",
                         &share_id, &channel_id, &job_id
                     );
                 }
+                translated_share
             }
             // Proxy do not have JD capabilities
             Ok(OnNewShare::ShareMeetBitcoinTarget(..)) => unreachable!(),
-            Err(roles_logic_sv2::Error::NoValidJob) => {
-                let count = SUBMIT_FAIL_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
-                if count >= 10 {
-                    error!("Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message after 10 attempts");
-                    return Err(Error::RolesSv2Logic(roles_logic_sv2::Error::NoValidJob));
-                } else {
-                    warn!(
-                        "Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message, attempt {}",
-                        count
-                    );
-                }
-            }
-            Err(roles_logic_sv2::Error::ShareDoNotMatchAnyJob) => {
-                warn!(
-                    "Channel factory can not get this share's job_id: {}",
-                    job_id
-                );
-            }
             Err(e) => {
+                Self::resolve_submit(
+                    result_tx,
+                    Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
+                );
                 return Err(Error::RolesSv2Logic(e));
             }
+        };
+
+        if let Ok(is_rate_limited) = allow_submit_share() {
+            if !is_rate_limited {
+                warn!("Share will not be sent upstream: Exceeded 70 shares/min limit");
+                Self::resolve_submit(
+                    result_tx,
+                    Err(crate::monitor::shares::RejectionReason::RateLimited),
+                );
+                return Ok(());
+            }
+        } else {
+            error!("Failed to record share: Bridge mutex poisoned");
+            ProxyState::update_inconsistency(Some(1));
+            Self::resolve_submit(
+                result_tx,
+                Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
+            );
+            return Err(Error::BridgeMutexPoisoned);
+        }
+
+        if let Err(e) = tx_sv2_submit_shares_ext
+            .send(UpstreamSubmitShare {
+                share: upstream_share,
+                result_tx,
+            })
+            .await
+        {
+            error!("Failed to send SubmitShareExtended upstream");
+            Self::resolve_submit(
+                e.0.result_tx,
+                Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
+            );
+            return Err(Error::AsyncChannelError);
         }
         Ok(())
     }

--- a/src/translator/upstream/upstream.rs
+++ b/src/translator/upstream/upstream.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    downstream::Downstream,
+    downstream::{Downstream, SubmitShareResult, SubmitShareResultSender, UpstreamSubmitShare},
     error::{Error, ProxyResult},
     upstream::diff_management::UpstreamDifficultyConfig,
 };
@@ -22,6 +22,7 @@ use roles_logic_sv2::{
     Error as RolesLogicError,
 };
 use std::{
+    collections::BTreeMap,
     sync::{atomic::AtomicBool, Arc},
     time::Duration,
 };
@@ -35,6 +36,7 @@ use super::task_manager::TaskManager;
 use crate::{
     proxy_state::{ProxyState, UpstreamType},
     shared::utils::AbortOnDrop,
+    translator::utils::submit_error_to_rejection_reason,
 };
 use bitcoin::BlockHash;
 
@@ -90,6 +92,8 @@ pub struct Upstream {
     sent_up: u32,
     rejected: u32,
     toa: Vec<std::time::Instant>,
+    next_submit_sequence: u32,
+    pending_submits: BTreeMap<u32, SubmitShareResultSender>,
 }
 
 impl PartialEq for Upstream {
@@ -132,13 +136,15 @@ impl Upstream {
             sent_up: 0,
             rejected: 0,
             toa: Vec::new(),
+            next_submit_sequence: 0,
+            pending_submits: BTreeMap::new(),
         })))
     }
 
     pub async fn start(
         self_: Arc<Mutex<Self>>,
         incoming_receiver: TReceiver<Mining<'static>>,
-        rx_sv2_submit_shares_ext: TReceiver<SubmitSharesExtended<'static>>,
+        rx_sv2_submit_shares_ext: TReceiver<UpstreamSubmitShare>,
         rx_update_token: TReceiver<String>,
     ) -> Result<AbortOnDrop, Error<'static>> {
         let task_manager = TaskManager::initialize();
@@ -449,9 +455,55 @@ impl Upstream {
         Ok((diff_manager_handle.into(), main_loop_handle.into()))
     }
 
+    fn register_pending_submit(&mut self, result_tx: SubmitShareResultSender) -> u32 {
+        let sequence_number = self.next_submit_sequence;
+        self.next_submit_sequence = self.next_submit_sequence.wrapping_add(1);
+        self.pending_submits.insert(sequence_number, result_tx);
+        sequence_number
+    }
+
+    fn resolve_submit_success(&mut self, last_sequence_number: u32, accepted_count: u32) {
+        if accepted_count == 0 {
+            return;
+        }
+
+        let acknowledged_sequences: Vec<u32> = self
+            .pending_submits
+            .range(..=last_sequence_number)
+            .map(|(sequence_number, _)| *sequence_number)
+            .take(accepted_count as usize)
+            .collect();
+
+        if acknowledged_sequences.len() < accepted_count as usize {
+            warn!(
+                "SubmitSharesSuccess acknowledged {} shares up to sequence {}, but only {} pending submits were available",
+                accepted_count,
+                last_sequence_number,
+                acknowledged_sequences.len()
+            );
+        }
+
+        for sequence_number in acknowledged_sequences {
+            if let Some(result_tx) = self.pending_submits.remove(&sequence_number) {
+                let _ = result_tx.send(Ok(()));
+            }
+        }
+    }
+
+    fn resolve_submit_error(&mut self, sequence_number: u32, result: SubmitShareResult) {
+        if let Some(result_tx) = self.pending_submits.remove(&sequence_number) {
+            let _ = result_tx.send(result);
+        } else {
+            warn!(
+                "Received submit error for unknown pending sequence {}",
+                sequence_number
+            );
+        }
+    }
+
     fn handle_submit(
         self_: Arc<Mutex<Self>>,
-        mut rx_submit: TReceiver<SubmitSharesExtended<'static>>,
+        mut rx_submit: TReceiver<UpstreamSubmitShare>,
     ) -> ProxyResult<'static, AbortOnDrop> {
         let tx_frame = self_
             .safe_lock(|s| s.sender.clone())
@@ -461,7 +513,10 @@ impl Upstream {
             let self_ = self_.clone();
             task::spawn(async move {
                 loop {
-                    let mut sv2_submit: SubmitSharesExtended = match rx_submit.recv().await {
+                    let UpstreamSubmitShare {
+                        mut share,
+                        result_tx,
+                    } = match rx_submit.recv().await {
                         Some(msg) => msg,
                         None => {
                             error!("Failed to receive SubmitShare message");
@@ -469,37 +524,64 @@ impl Upstream {
                         }
                     };
 
-                    let channel_id = match self_.safe_lock(|s| s.channel_id) {
-                        Ok(Some(channel_id)) => channel_id,
-                        Ok(None) => {
-                            error!(
-                                "{}",
-                                Error::RolesSv2Logic(RolesLogicError::NotFoundChannelId)
-                            );
+                    let (channel_id, signature) = match self_.safe_lock(|s| {
+                        s.channel_id
+                            .ok_or(RolesLogicError::NotFoundChannelId)
+                            .map(|channel_id| (channel_id, s.signature.clone()))
+                    }) {
+                        Ok(Ok(values)) => values,
+                        Ok(Err(e)) => {
+                            error!("{}", Error::RolesSv2Logic(e));
+                            let _ = result_tx.send(Err(
+                                crate::monitor::shares::RejectionReason::UpstreamRejected,
+                            ));
                             return;
                         }
                         Err(e) => {
                             error!("Translator upstream mutex corrupted: {e}");
-                            return;
-                        }
-                    };
-                    let signature = match self_.safe_lock(|s| s.signature.clone()) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            error!("Translator upstream mutex corrupted: {e}");
+                            let _ = result_tx.send(Err(
+                                crate::monitor::shares::RejectionReason::UpstreamRejected,
+                            ));
                             return;
                         }
                     };
 
-                    sv2_submit.channel_id = channel_id;
+                    let mut pending_result_tx = Some(result_tx);
+                    let sequence_number = match self_.safe_lock(|s| {
+                        s.register_pending_submit(
+                            pending_result_tx
+                                .take()
+                                .expect("pending submit result sender must be available"),
+                        )
+                    }) {
+                        Ok(sequence_number) => sequence_number,
+                        Err(e) => {
+                            error!("Translator upstream mutex corrupted: {e}");
+                            if let Some(result_tx) = pending_result_tx {
+                                let _ = result_tx.send(Err(
+                                    crate::monitor::shares::RejectionReason::UpstreamRejected,
+                                ));
+                            }
+                            return;
+                        }
+                    };
+
+                    share.channel_id = channel_id;
+                    share.sequence_number = sequence_number;
                     let mut extranonce = signature.as_bytes().to_vec();
-                    extranonce.extend_from_slice(&sv2_submit.extranonce.to_vec());
-                    sv2_submit.extranonce = extranonce.try_into().unwrap();
+                    extranonce.extend_from_slice(&share.extranonce.to_vec());
+                    share.extranonce = extranonce.try_into().unwrap();
 
-                    let message =
-                        roles_logic_sv2::parsers::Mining::SubmitSharesExtended(sv2_submit);
+                    let message = roles_logic_sv2::parsers::Mining::SubmitSharesExtended(share);
 
                     if tx_frame.send(message).await.is_err() {
+                        if let Ok(Some(result_tx)) =
+                            self_.safe_lock(|s| s.pending_submits.remove(&sequence_number))
+                        {
+                            let _ = result_tx.send(Err(
+                                crate::monitor::shares::RejectionReason::UpstreamRejected,
+                            ));
+                        }
                         error!("Unable to send SubmitSharesExtended msg upstream");
                         return;
                     };
@@ -706,18 +788,26 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
     /// Handles the SV2 `SubmitSharesSuccess` message.
     fn handle_submit_shares_success(
         &mut self,
-        _m: roles_logic_sv2::mining_sv2::SubmitSharesSuccess,
+        m: roles_logic_sv2::mining_sv2::SubmitSharesSuccess,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
+        self.resolve_submit_success(m.last_sequence_number, m.new_submits_accepted_count);
         Ok(SendTo::None(None))
     }
 
     /// Handles the SV2 `SubmitSharesError` message.
     fn handle_submit_shares_error(
         &mut self,
-        _m: roles_logic_sv2::mining_sv2::SubmitSharesError,
+        m: roles_logic_sv2::mining_sv2::SubmitSharesError,
     ) -> Result<roles_logic_sv2::handlers::mining::SendTo<Downstream>, RolesLogicError> {
         self.rejected += 1;
-        error!("Ops rejected share");
+        let error_code = std::str::from_utf8(&m.error_code.to_vec())
+            .unwrap_or("unparsable error code")
+            .to_string();
+        self.resolve_submit_error(
+            m.sequence_number,
+            Err(submit_error_to_rejection_reason(&error_code)),
+        );
+        error!("Pool rejected share with error code {}", error_code);
         Ok(SendTo::None(None))
     }
 
@@ -836,4 +926,100 @@ fn avg_seconds_between(instants: &[std::time::Instant]) -> f64 {
         .sum();
 
     total_secs / (instants.len() - 1) as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monitor::shares::RejectionReason;
+    use tokio::sync::{mpsc, oneshot};
+
+    async fn test_upstream() -> Arc<Mutex<Upstream>> {
+        let (tx_sv2_set_new_prev_hash, _rx_sv2_set_new_prev_hash) = mpsc::channel(1);
+        let (tx_sv2_new_ext_mining_job, _rx_sv2_new_ext_mining_job) = mpsc::channel(1);
+        let (tx_sv2_extranonce, _rx_sv2_extranonce) = mpsc::channel(1);
+        let (sender, _receiver) = mpsc::channel(1);
+
+        Upstream::new(
+            tx_sv2_set_new_prev_hash,
+            tx_sv2_new_ext_mining_job,
+            crate::MIN_EXTRANONCE_SIZE - 1,
+            tx_sv2_extranonce,
+            Arc::new(Mutex::new(vec![0; 32])),
+            Arc::new(Mutex::new(UpstreamDifficultyConfig {
+                channel_diff_update_interval: crate::CHANNEL_DIFF_UPDTATE_INTERVAL,
+                channel_nominal_hashrate: 0.0,
+            })),
+            sender,
+            "sig".to_string(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn submit_success_resolves_pending_submit() {
+        let upstream = test_upstream().await;
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let sequence_number = upstream
+            .safe_lock(|u| u.register_pending_submit(result_tx))
+            .unwrap();
+        assert_eq!(sequence_number, 0);
+
+        upstream
+            .safe_lock(|u| u.resolve_submit_success(sequence_number, 1))
+            .unwrap();
+
+        assert_eq!(result_rx.await.unwrap(), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn submit_error_resolves_pending_submit() {
+        let upstream = test_upstream().await;
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let sequence_number = upstream
+            .safe_lock(|u| u.register_pending_submit(result_tx))
+            .unwrap();
+        upstream
+            .safe_lock(|u| {
+                u.resolve_submit_error(sequence_number, Err(RejectionReason::JobIdNotFound))
+            })
+            .unwrap();
+
+        assert_eq!(
+            result_rx.await.unwrap(),
+            Err(RejectionReason::JobIdNotFound)
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_success_skips_already_rejected_sequence() {
+        let upstream = test_upstream().await;
+        let (first_result_tx, first_result_rx) = oneshot::channel();
+        let (second_result_tx, second_result_rx) = oneshot::channel();
+
+        let (first_sequence, second_sequence) = upstream
+            .safe_lock(|u| {
+                (
+                    u.register_pending_submit(first_result_tx),
+                    u.register_pending_submit(second_result_tx),
+                )
+            })
+            .unwrap();
+
+        upstream
+            .safe_lock(|u| {
+                u.resolve_submit_error(first_sequence, Err(RejectionReason::JobIdNotFound));
+                u.resolve_submit_success(second_sequence, 1);
+            })
+            .unwrap();
+
+        assert_eq!(
+            first_result_rx.await.unwrap(),
+            Err(RejectionReason::JobIdNotFound)
+        );
+        assert_eq!(second_result_rx.await.unwrap(), Ok(()));
+    }
 }

--- a/src/translator/utils.rs
+++ b/src/translator/utils.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     config::Configuration,
+    monitor::shares::RejectionReason,
     proxy_state::{DownstreamType, ProxyState},
     share_log_enabled,
     translator::error::Error,
@@ -110,10 +111,10 @@ pub fn allow_submit_share() -> crate::translator::error::ProxyResult<'static, bo
 pub fn validate_share(
     request: &client_to_server::Submit<'static>,
     job: &Notify<'static>,
-    difficulties: &VecDeque<f32>,
+    difficulty: f32,
     extranonce1: Vec<u8>,
     version_rolling_mask: Option<sv1_api::utils::HexU32Be>,
-) -> Option<f32> {
+) -> bool {
     if share_log_enabled() {
         info!(
             "Validating share from request {} and job {}",
@@ -126,7 +127,7 @@ pub fn validate_share(
         Ok(hash) => hash,
         Err(e) => {
             error!("Share rejected: Invalid previous hash: {:?}", e);
-            return None;
+            return false;
         }
     };
     let mut merkle_branch = Vec::new();
@@ -164,25 +165,39 @@ pub fn validate_share(
     if share_log_enabled() {
         info!("Share Hash: {:?}", hash.to_vec().as_hex());
     }
-    // Check against difficulties from latest to earliest
-    // TODO: This is not a sound check - We should check against the difficulty of the specific job
-    for &difficulty in difficulties.iter().rev() {
-        let target = Downstream::difficulty_to_target(difficulty);
-        debug!(
-            "Checking difficulty: {}, Target: {:?}",
-            difficulty,
-            target.to_vec().as_hex()
-        );
-        if hash <= target {
-            if share_log_enabled() {
-                info!("Share met Target: {:?}", target.to_vec().as_hex());
-            }
-            return Some(difficulty); // Return the difficulty met
+    let target = Downstream::difficulty_to_target(difficulty);
+    debug!(
+        "Checking job difficulty: {}, Target: {:?}",
+        difficulty,
+        target.to_vec().as_hex()
+    );
+    if hash <= target {
+        if share_log_enabled() {
+            info!("Share met Target: {:?}", target.to_vec().as_hex());
         }
+        return true;
     }
 
-    error!("Share rejected: Does not meet any difficulty");
-    None // Share does not meet any difficulty
+    error!("Share rejected: Does not meet job difficulty");
+    false
+}
+
+pub fn submit_error_to_rejection_reason(error_code: &str) -> RejectionReason {
+    match error_code {
+        code if code
+            == roles_logic_sv2::mining_sv2::SubmitSharesError::difficulty_too_low_error_code() =>
+        {
+            RejectionReason::DifficultyMismatch
+        }
+        code if code
+            == roles_logic_sv2::mining_sv2::SubmitSharesError::stale_share_error_code()
+            || code
+                == roles_logic_sv2::mining_sv2::SubmitSharesError::invalid_job_id_error_code() =>
+        {
+            RejectionReason::JobIdNotFound
+        }
+        _ => RejectionReason::UpstreamRejected,
+    }
 }
 
 pub fn get_hash(


### PR DESCRIPTION
Snapshot the active downstream difficulty on each issued SV1 job id while preserving the retained three-job history, so late shares are validated against the exact job they were issued for instead of whichever recent difficulty still matches.

Keep miner-facing submit handling optimistic for shares that are valid at downstream difficulty by replying immediately after local job-bound validation and translator handoff, while routing the correlated upstream result only into monitoring and accepted/ rejected accounting. This prevents stale retained difficulties from inflating accepted accounting without changing the current downstream submit-ok behavior."