### PR TITLE
FIX reconcile bootstrap hashrate before the first downstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmnd-client"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 
 [lib]

--- a/src/translator/downstream/diff_management.rs
+++ b/src/translator/downstream/diff_management.rs
@@ -199,9 +199,11 @@ impl Downstream {
 
     /// 1. Calculates the realized share rate since the last update.
     /// 2. Adjusts difficulty using a PID controller, with aggressive tuning for zero-share cases over 5 secs.
-    /// 3. Estimates a new hash rate and updates the miner’s state if a change is needed.
+    /// 3. Estimates a new hash rate and reconciles the miner state immediately, even when the
+    ///    quantized difficulty bucket stays unchanged.
     ///
-    /// Returns `Some(new_difficulty)` if updated, or `None` if no update is needed.
+    /// Returns `Some(new_difficulty)` when a new downstream difficulty should be sent, or `None`
+    /// when no `mining.set_difficulty` update is needed.
     pub fn update_difficulty_and_hashrate(
         self_: &Arc<Mutex<Self>>,
     ) -> ProxyResult<'static, Option<f32>> {
@@ -249,7 +251,10 @@ impl Downstream {
             (latest_difficulty + pid_output).max(initial_difficulty * 0.1),
             hard_minimum_difficulty,
         );
+        let new_estimation =
+            Self::estimate_hash_rate_from_difficulty(new_difficulty, *crate::SHARE_PER_MIN);
         if new_difficulty == latest_difficulty {
+            Self::reconcile_hash_rate_estimation(self_, new_estimation)?;
             return Ok(None);
         }
 
@@ -265,8 +270,6 @@ impl Downstream {
             })?;
         }
 
-        let new_estimation =
-            Self::estimate_hash_rate_from_difficulty(new_difficulty, *crate::SHARE_PER_MIN);
         Self::update_self_with_new_hash_rate(self_, new_estimation, new_difficulty)?;
         Ok(Some(new_difficulty))
     }
@@ -278,28 +281,38 @@ impl Downstream {
         share_per_second * difficulty * 2f32.powi(32)
     }
 
-    /// Updates the downstream miner's difficulty mgmt states and adjusts the upstream channel's nominal
-    fn update_self_with_new_hash_rate(
+    fn hashrate_estimation_changed(old_estimation: f32, new_estimation: f32) -> bool {
+        let tolerance =
+            f32::EPSILON * old_estimation.abs().max(new_estimation.abs()).max(1.0) * 16.0;
+        (old_estimation - new_estimation).abs() > tolerance
+    }
+
+    fn reconcile_hash_rate_estimation(
         self_: &Arc<Mutex<Self>>,
         new_estimation: f32,
-        current_diff: f32,
     ) -> ProxyResult<'static, ()> {
-        let (upstream_difficulty_config, old_estimation, connection_id, stats_sender) = self_
-            .safe_lock(|d| {
+        let (upstream_difficulty_config, old_estimation, connection_id, stats_sender, changed) =
+            self_.safe_lock(|d| {
                 let old_estimation = d.difficulty_mgmt.estimated_downstream_hash_rate;
-                d.difficulty_mgmt.estimated_downstream_hash_rate = new_estimation;
-                d.difficulty_mgmt.reset();
-                d.difficulty_mgmt.add_difficulty(current_diff);
+                let changed = Self::hashrate_estimation_changed(old_estimation, new_estimation);
+                if changed {
+                    d.difficulty_mgmt.estimated_downstream_hash_rate = new_estimation;
+                }
 
                 (
                     d.upstream_difficulty_config.clone(),
                     old_estimation,
                     d.connection_id,
                     d.stats_sender.clone(),
+                    changed,
                 )
             })?;
+
+        if !changed {
+            return Ok(());
+        }
+
         stats_sender.update_hashrate(connection_id, new_estimation);
-        stats_sender.update_diff(connection_id, current_diff);
         let hash_rate_delta = new_estimation - old_estimation;
         upstream_difficulty_config.safe_lock(|c| {
             if (c.channel_nominal_hashrate + hash_rate_delta) > 0.0 {
@@ -308,6 +321,23 @@ impl Downstream {
                 c.channel_nominal_hashrate = 0.0;
             }
         })?;
+        Ok(())
+    }
+
+    /// Updates the downstream miner's difficulty mgmt states and adjusts the upstream channel's nominal
+    fn update_self_with_new_hash_rate(
+        self_: &Arc<Mutex<Self>>,
+        new_estimation: f32,
+        current_diff: f32,
+    ) -> ProxyResult<'static, ()> {
+        let (connection_id, stats_sender) = self_.safe_lock(|d| {
+            d.difficulty_mgmt.reset();
+            d.difficulty_mgmt.add_difficulty(current_diff);
+
+            (d.connection_id, d.stats_sender.clone())
+        })?;
+        stats_sender.update_diff(connection_id, current_diff);
+        Self::reconcile_hash_rate_estimation(self_, new_estimation)?;
         Ok(())
     }
 }
@@ -378,7 +408,10 @@ mod test {
         hard_minimum_difficulty_for_proxy_mode, nearest_power_of_2, quantize_downstream_difficulty,
         NON_LOCAL_DOWNSTREAM_MIN_DIFFICULTY,
     };
-    use crate::translator::downstream::{downstream::DownstreamDifficultyConfig, Downstream};
+    use crate::{
+        api::stats::StatsSender,
+        translator::downstream::{downstream::DownstreamDifficultyConfig, Downstream},
+    };
     use binary_sv2::U256;
     use pid::Pid;
     use rand::{thread_rng, Rng};
@@ -483,6 +516,109 @@ mod test {
         let share_per_second = *crate::SHARE_PER_MIN / 60.0;
         let initial_difficulty = hashrate / (share_per_second * 2f32.powf(32.0));
         crate::translator::downstream::diff_management::nearest_power_of_2(initial_difficulty)
+    }
+
+    const RAW_BOOTSTRAP_HASHRATE: f32 = 500_000_000_000_000.0;
+
+    fn hashrate_for_diff(diff: f32) -> f32 {
+        let share_per_second = *crate::SHARE_PER_MIN / 60.0;
+        share_per_second * diff * 2f32.powi(32)
+    }
+
+    fn target_rate_submits() -> VecDeque<Instant> {
+        let oldest = Instant::now() - Duration::from_secs(30);
+        std::iter::repeat_n(oldest,5).collect()
+    }
+
+    fn assert_hashrate_close(actual: f32, expected: f32) {
+        let tolerance = expected.abs().max(1.0) * 0.001;
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "expected hashrate near {expected}, got {actual}",
+        );
+    }
+
+    fn seeded_downstream(
+        estimated_downstream_hash_rate: f32,
+        latest_difficulty: f32,
+        pid_controller: Pid<f32>,
+        submits: VecDeque<Instant>,
+        channel_nominal_hashrate: f32,
+    ) -> (Arc<Mutex<Downstream>>, Arc<Mutex<UpstreamDifficultyConfig>>) {
+        let mut current_difficulties = VecDeque::new();
+        current_difficulties.push_back(latest_difficulty);
+        let difficulty_mgmt = DownstreamDifficultyConfig {
+            estimated_downstream_hash_rate,
+            submits,
+            pid_controller,
+            current_difficulties,
+            initial_difficulty: latest_difficulty,
+            hard_minimum_difficulty: None,
+        };
+        let upstream_config = Arc::new(Mutex::new(UpstreamDifficultyConfig {
+            channel_diff_update_interval: 60,
+            channel_nominal_hashrate,
+        }));
+        let (tx_sv1_submit, _rx_sv1_submit) = tokio::sync::mpsc::channel(10);
+        let (tx_outgoing, _rx_outgoing) = channel(10);
+        let (tx_update_token, _rx_update_token) = channel(10);
+        let first_job = Notify {
+            job_id: "seed".to_string(),
+            prev_hash: PrevHash::try_from("0".repeat(64).as_str()).unwrap(),
+            coin_base1: "ffff".try_into().unwrap(),
+            coin_base2: "ffff".try_into().unwrap(),
+            merkle_branch: vec![MerkleNode::try_from(vec![7_u8; 32]).unwrap()],
+            version: HexU32Be(5667),
+            bits: HexU32Be(5678),
+            time: HexU32Be(5609),
+            clean_jobs: true,
+        };
+
+        (
+            Arc::new(Mutex::new(Downstream::new(
+                1,
+                vec![],
+                vec![],
+                None,
+                None,
+                tx_sv1_submit,
+                tx_outgoing,
+                0,
+                difficulty_mgmt,
+                upstream_config.clone(),
+                StatsSender::new(),
+                first_job,
+                tx_update_token,
+            ))),
+            upstream_config,
+        )
+    }
+
+    #[tokio::test]
+    async fn initial_seed_is_not_reconciled_when_quantized_difficulty_is_unchanged() {
+        let quantized_difficulty = get_diff(RAW_BOOTSTRAP_HASHRATE);
+        let quantized_hashrate = hashrate_for_diff(quantized_difficulty);
+        let pid = Pid::new(*crate::SHARE_PER_MIN, quantized_difficulty * 10.0);
+
+        let (downstream, upstream_config) = seeded_downstream(
+            RAW_BOOTSTRAP_HASHRATE,
+            quantized_difficulty,
+            pid,
+            target_rate_submits(),
+            RAW_BOOTSTRAP_HASHRATE,
+        );
+
+        Downstream::update_difficulty_and_hashrate(&downstream).unwrap();
+
+        let estimated_downstream_hash_rate = downstream
+            .safe_lock(|d| d.difficulty_mgmt.estimated_downstream_hash_rate)
+            .unwrap();
+        let channel_nominal_hashrate = upstream_config
+            .safe_lock(|u| u.channel_nominal_hashrate)
+            .unwrap();
+
+        assert_hashrate_close(estimated_downstream_hash_rate, quantized_hashrate);
+        assert_hashrate_close(channel_nominal_hashrate, quantized_hashrate);
     }
 
     #[test]

--- a/src/translator/downstream/notify.rs
+++ b/src/translator/downstream/notify.rs
@@ -1,4 +1,3 @@
-use crate::config::Configuration;
 use crate::proxy_state::{DownstreamType, ProxyState};
 use crate::translator::downstream::SUBSCRIBE_TIMEOUT_SECS;
 use crate::translator::error::Error;
@@ -41,16 +40,17 @@ pub async fn start_notify(
 
     let handle = {
         let task_manager = task_manager.clone();
-        let (upstream_difficulty_config, stats_sender, latest_diff) =
+        let (upstream_difficulty_config, stats_sender, latest_diff, registered_hashrate) =
             downstream.safe_lock(|d| {
                 (
                     d.upstream_difficulty_config.clone(),
                     d.stats_sender.clone(),
                     d.difficulty_mgmt.current_difficulties.back().copied(),
+                    d.difficulty_mgmt.estimated_downstream_hash_rate,
                 )
             })?;
         upstream_difficulty_config
-            .safe_lock(|c| c.channel_nominal_hashrate += Configuration::downstream_hashrate())?;
+            .safe_lock(|c| c.channel_nominal_hashrate += registered_hashrate)?;
         downstream.safe_lock(|d| d.mark_channel_hashrate_registered())?;
         if let Err(e) = stats_sender.setup_stats_reliable(connection_id).await {
             error!("Failed to register downstream stats {connection_id}: {e}");
@@ -64,10 +64,8 @@ pub async fn start_notify(
             let should_subtract = downstream.safe_lock(|d| d.take_channel_hashrate_registered())?;
             if should_subtract {
                 upstream_difficulty_config.safe_lock(|u| {
-                    u.channel_nominal_hashrate -= f32::min(
-                        Configuration::downstream_hashrate(),
-                        u.channel_nominal_hashrate,
-                    );
+                    u.channel_nominal_hashrate -=
+                        f32::min(registered_hashrate, u.channel_nominal_hashrate);
                 })?;
             }
             return Ok(());
@@ -193,6 +191,12 @@ async fn start_update(
         // Prevent difficulty adjustments until after delay elapses
         tokio::time::sleep(std::time::Duration::from_secs(crate::Configuration::delay())).await;
         loop {
+            // Reconcile immediately after the delay instead of waiting a full interval first.
+            if let Err(e) = Downstream::try_update_difficulty_settings(&downstream).await {
+                error!("{e}");
+                return;
+            };
+
             let share_count = crate::translator::utils::get_share_count(connection_id);
             let sleep_duration = if share_count >= *crate::SHARE_PER_MIN * 3.0
                 || share_count <= *crate::SHARE_PER_MIN / 3.0
@@ -204,13 +208,6 @@ async fn start_update(
             };
 
             tokio::time::sleep(sleep_duration).await;
-
-            // if hashrate has changed, update difficulty management, and send new
-            // mining.set_difficulty
-            if let Err(e) = Downstream::try_update_difficulty_settings(&downstream).await {
-                error!("{e}");
-                return;
-            };
         }
     });
     TaskManager::add_update(task_manager, handle.into(), connection_id)
@@ -220,7 +217,7 @@ async fn start_update(
 
 #[cfg(test)]
 mod tests {
-    use super::{current_or_initial_job, start_notify};
+    use super::{current_or_initial_job, start_notify, start_update};
     use crate::{
         api::stats::StatsSender,
         translator::{
@@ -234,12 +231,18 @@ mod tests {
     };
     use pid::Pid;
     use roles_logic_sv2::utils::Mutex;
-    use std::{collections::VecDeque, sync::Arc, time::Duration};
+    use std::{
+        collections::VecDeque,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
     use sv1_api::{
         server_to_client::Notify,
         utils::{HexU32Be, MerkleNode, PrevHash},
     };
     use tokio::sync::{broadcast, mpsc::channel};
+
+    const RAW_BOOTSTRAP_HASHRATE: f32 = 500_000_000_000_000.0;
 
     fn first_job(job_id: &str) -> Notify<'static> {
         Notify {
@@ -300,6 +303,73 @@ mod tests {
         )
     }
 
+    fn quantized_difficulty_for_hashrate(hashrate: f32) -> f32 {
+        let share_per_second = *crate::SHARE_PER_MIN / 60.0;
+        let raw_difficulty = hashrate / (share_per_second * 2f32.powi(32));
+        crate::translator::downstream::diff_management::quantize_downstream_difficulty(
+            raw_difficulty,
+            None,
+        )
+    }
+
+    fn hashrate_for_diff(diff: f32) -> f32 {
+        let share_per_second = *crate::SHARE_PER_MIN / 60.0;
+        share_per_second * diff * 2f32.powi(32)
+    }
+
+    fn assert_hashrate_close(actual: f32, expected: f32) {
+        let tolerance = expected.abs().max(1.0) * 0.001;
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "expected hashrate near {expected}, got {actual}",
+        );
+    }
+
+    fn seeded_downstream_for_update_loop(
+        estimated_downstream_hash_rate: f32,
+        latest_difficulty: f32,
+        pid_controller: Pid<f32>,
+        submits: VecDeque<Instant>,
+        channel_nominal_hashrate: f32,
+    ) -> (Arc<Mutex<Downstream>>, Arc<Mutex<UpstreamDifficultyConfig>>) {
+        let mut current_difficulties = VecDeque::new();
+        current_difficulties.push_back(latest_difficulty);
+        let difficulty_mgmt = DownstreamDifficultyConfig {
+            estimated_downstream_hash_rate,
+            submits,
+            pid_controller,
+            current_difficulties,
+            initial_difficulty: latest_difficulty,
+            hard_minimum_difficulty: None,
+        };
+        let upstream_config = Arc::new(Mutex::new(UpstreamDifficultyConfig {
+            channel_diff_update_interval: crate::CHANNEL_DIFF_UPDTATE_INTERVAL,
+            channel_nominal_hashrate,
+        }));
+        let (tx_sv1_submit, _rx_sv1_submit) = channel::<DownstreamMessages>(8);
+        let (tx_outgoing, _rx_outgoing) = channel(8);
+        let (tx_update_token, _rx_update_token) = channel(8);
+
+        (
+            Arc::new(Mutex::new(Downstream::new(
+                1,
+                vec!["worker".to_string()],
+                vec![],
+                None,
+                None,
+                tx_sv1_submit,
+                tx_outgoing,
+                0,
+                difficulty_mgmt,
+                upstream_config.clone(),
+                StatsSender::new(),
+                first_job("88"),
+                tx_update_token,
+            ))),
+            upstream_config,
+        )
+    }
+
     #[tokio::test]
     async fn current_or_initial_job_seeds_recent_jobs_without_mutating_snapshot() {
         let first_job = first_job("42");
@@ -349,5 +419,47 @@ mod tests {
         if let Some(aborter) = task_manager.safe_lock(|t| t.get_aborter()).unwrap() {
             drop(aborter);
         }
+    }
+
+    #[tokio::test]
+    async fn first_retarget_waits_full_adjustment_interval_before_fixing_upstream_hashrate() {
+        let quantized_difficulty = quantized_difficulty_for_hashrate(RAW_BOOTSTRAP_HASHRATE);
+        let expected_first_retarget_hashrate = hashrate_for_diff(quantized_difficulty / 2.0);
+        let mut pid = Pid::new(*crate::SHARE_PER_MIN, quantized_difficulty * 10.0);
+        // If the first retarget runs immediately, this forces the bootstrap seed down one bucket.
+        pid.p(-(quantized_difficulty * 0.05), f32::MAX)
+            .i(0.0, f32::MAX)
+            .d(0.0, f32::MAX);
+
+        let (downstream, upstream_config) = seeded_downstream_for_update_loop(
+            RAW_BOOTSTRAP_HASHRATE,
+            quantized_difficulty,
+            pid,
+            VecDeque::new(),
+            RAW_BOOTSTRAP_HASHRATE,
+        );
+        let task_manager = TaskManager::initialize();
+
+        start_update(task_manager.clone(), downstream.clone(), 1)
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let last_call_to_update_hr = downstream.safe_lock(|d| d.last_call_to_update_hr).unwrap();
+        let channel_nominal_hashrate = upstream_config
+            .safe_lock(|u| u.channel_nominal_hashrate)
+            .unwrap();
+
+        if let Some(aborter) = task_manager.safe_lock(|t| t.get_aborter()).unwrap() {
+            drop(aborter);
+        }
+
+        assert_ne!(
+            last_call_to_update_hr, 0,
+            "the first retarget should reconcile the bootstrap seed immediately instead of waiting a full adjustment interval",
+        );
+        assert_hashrate_close(channel_nominal_hashrate, expected_first_retarget_hashrate);
     }
 }


### PR DESCRIPTION
retarget

Reconcile the miner hashrate estimate as soon as share-rate data is available, even when the
quantized difficulty bucket does not change. The bootstrap seed can overstate nominal upstream
hashrate while still mapping to the same bucket, so waiting for a later bucket transition leaves
the aggregate channel inflated for a full adjustment interval.

Register the current downstream estimate during bootstrap and run the first difficulty update
immediately after the configured delay so upstream nominal hashrate converges to the bucket-backed
estimate without waiting for a later retarget.