### PR TITLE
FIX tx prioritization auth and mined-tx template checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Example using `config.toml`:
 
 When the client is running, submit a raw transaction hex to:
 
-    POST http://<dmnd-client-host>:<api-server-port>/api/tx/<raw-transaction-hex>
+    POST http://<dmnd-client-host>:<api-server-port>/api/tx/submit/<raw-transaction-hex>
 
 The API server port defaults to `3001` and can be changed with `--api-server-port`,
 `api_server_port`, or `API_SERVER_PORT`.
@@ -146,7 +146,7 @@ Example:
 
     curl -X POST \
       -H "Authorization: Bearer <api-token>" \
-      "http://127.0.0.1:3001/api/tx/<raw-transaction-hex>"
+      "http://127.0.0.1:3001/api/tx/submit/<raw-transaction-hex>"
 
 If the prioritization configuration is incomplete, this endpoint is disabled. In that case the
 client logs that transaction prioritization is not enabled and the endpoint returns `503 Service

--- a/README.md
+++ b/README.md
@@ -100,5 +100,57 @@ You can track your hashrate and earnings on the DMND pool dashboard:
 
 Login with the same credentials you used during registration.
 
+# 7. Prioritize Transactions
+--------------------------------------
+The DMND Stratum V2 Client can expose an API endpoint that sends a raw transaction to Bitcoin Core
+and asks Bitcoin Core to prioritize that transaction for block template selection.
+
+This feature is enabled only when all of the following values are configured:
+
+- `RPC_URL`: Bitcoin Core RPC URL, for example `http://127.0.0.1:8332`.
+- `RPC_USER`: Bitcoin Core RPC username.
+- `RPC_PWD`: Bitcoin Core RPC password.
+- `RPC_FEE_DELTA`: fee delta, in satoshis, passed to Bitcoin Core's `prioritisetransaction` RPC.
+- `API_TX_TOKEN`: bearer token required by the DMND Client transaction API.
+
+You can set these values with CLI flags (`--rpc-url`, `--rpc-user`, `--rpc-pwd`,
+`--rpc-fee-delta`, `--api-tx-token`), in `config.toml`, or with environment variables. CLI flags
+take precedence over `config.toml`, and `config.toml` takes precedence over environment variables.
+
+Example using environment variables:
+
+    TOKEN=<DMND-token> \
+    RPC_URL=http://127.0.0.1:8332 \
+    RPC_USER=<bitcoin-rpc-user> \
+    RPC_PWD=<bitcoin-rpc-password> \
+    RPC_FEE_DELTA=100000000 \
+    API_TX_TOKEN=<api-token> \
+    cargo run -- -l info -d <avg-hashrate>T --tp-address="127.0.0.1:8336"
+
+Example using `config.toml`:
+
+    rpc_url = "http://127.0.0.1:8332"
+    rpc_user = "<bitcoin-rpc-user>"
+    rpc_pwd = "<bitcoin-rpc-password>"
+    rpc_fee_delta = 100000000
+    api_tx_token = "<api-token>"
+
+When the client is running, submit a raw transaction hex to:
+
+    POST http://<dmnd-client-host>:<api-server-port>/api/tx/<raw-transaction-hex>
+
+The API server port defaults to `3001` and can be changed with `--api-server-port`,
+`api_server_port`, or `API_SERVER_PORT`.
+
+Example:
+
+    curl -X POST \
+      -H "Authorization: Bearer <api-token>" \
+      "http://127.0.0.1:3001/api/tx/<raw-transaction-hex>"
+
+If the prioritization configuration is incomplete, this endpoint is disabled. In that case the
+client logs that transaction prioritization is not enabled and the endpoint returns `503 Service
+Unavailable`.
+
 
 Happy Mining!

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -63,6 +63,38 @@ impl BitcoindRpc {
         }
     }
 
+    pub(crate) async fn transaction_in_mempool(
+        &self,
+        txid: &str,
+    ) -> Result<bool, BitcoindRpcError> {
+        let txid = validate_transaction_hex(txid)?;
+        let (status, text) = self.send_request("getmempoolentry", json!([txid])).await?;
+        let resp = RpcResponse::decode(status, &text)?;
+
+        if let Some(error) = resp.error {
+            if is_not_in_mempool_error(&error) {
+                return Ok(false);
+            }
+
+            return Err(BitcoindRpcError::Other(format!(
+                "bitcoind RPC error while checking mempool entry: {error}"
+            )));
+        }
+
+        if !status.is_success() {
+            return Err(BitcoindRpcError::Other(format!(
+                "bitcoind HTTP {status}: {text}"
+            )));
+        }
+
+        match resp.result {
+            Some(Value::Object(_)) => Ok(true),
+            _ => Err(BitcoindRpcError::InvalidResponse(format!(
+                "invalid getmempoolentry response from bitcoind: {text}"
+            ))),
+        }
+    }
+
     async fn send_request(
         &self,
         method: &str,
@@ -111,19 +143,7 @@ struct RpcResponse {
 
 impl RpcResponse {
     fn from_response(status: StatusCode, text: &str) -> Result<Option<Value>, BitcoindRpcError> {
-        let resp: Self = match serde_json::from_str(text) {
-            Ok(r) => r,
-            Err(e) if status.is_success() => {
-                return Err(BitcoindRpcError::InvalidResponse(format!(
-                    "failed to decode bitcoind response ({e}): {text}"
-                )));
-            }
-            Err(_) => {
-                return Err(BitcoindRpcError::Other(format!(
-                    "bitcoind HTTP {status}: {text}"
-                )));
-            }
-        };
+        let resp = Self::decode(status, text)?;
         if !status.is_success() {
             return Err(BitcoindRpcError::Other(format!(
                 "bitcoind HTTP {status}: {text}"
@@ -135,6 +155,18 @@ impl RpcResponse {
             )));
         }
         Ok(resp.result)
+    }
+
+    fn decode(status: StatusCode, text: &str) -> Result<Self, BitcoindRpcError> {
+        match serde_json::from_str(text) {
+            Ok(r) => Ok(r),
+            Err(e) if status.is_success() => Err(BitcoindRpcError::InvalidResponse(format!(
+                "failed to decode bitcoind response ({e}): {text}"
+            ))),
+            Err(_) => Err(BitcoindRpcError::Other(format!(
+                "bitcoind HTTP {status}: {text}"
+            ))),
+        }
     }
 }
 
@@ -158,6 +190,42 @@ fn validate_transaction_hex(tx: &str) -> Result<&str, BitcoindRpcError> {
         ));
     }
     Ok(tx)
+}
+
+fn is_not_in_mempool_error(error: &Value) -> bool {
+    let code_is_not_found = error.get("code").and_then(Value::as_i64) == Some(-5);
+    let message_says_not_in_mempool = error
+        .get("message")
+        .and_then(Value::as_str)
+        .is_some_and(|message| message.to_ascii_lowercase().contains("not in mempool"));
+
+    code_is_not_found || message_says_not_in_mempool
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_not_in_mempool_error;
+    use serde_json::json;
+
+    #[test]
+    fn detects_bitcoind_not_in_mempool_error() {
+        let error = json!({
+            "code": -5,
+            "message": "Transaction not in mempool"
+        });
+
+        assert!(is_not_in_mempool_error(&error));
+    }
+
+    #[test]
+    fn ignores_unrelated_bitcoind_errors() {
+        let error = json!({
+            "code": -26,
+            "message": "mandatory-script-verify-flag-failed"
+        });
+
+        assert!(!is_not_in_mempool_error(&error));
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -1,4 +1,5 @@
 use axum::http::StatusCode;
+use bitcoin::{blockdata::transaction::Transaction, consensus::encode::deserialize_hex};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{error::Error as StdError, fmt, time::Duration};
@@ -27,11 +28,7 @@ impl BitcoindRpc {
     pub(crate) async fn submit_transaction(&self, tx: &str) -> Result<String, BitcoindRpcError> {
         let tx = validate_transaction_hex(tx)?;
         let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
-        let txid = RpcResponse::from_response(status, &text)?
-            .and_then(|v| v.as_str().map(str::to_owned))
-            .ok_or_else(|| {
-                BitcoindRpcError::InvalidResponse("empty response from bitcoind".to_string())
-            })?;
+        let txid = txid_from_sendrawtransaction_response(tx, status, &text)?;
         self.prioritise_transaction(&txid).await?;
         crate::prioritized_transactions::record(&txid);
         Ok(txid)
@@ -135,6 +132,49 @@ impl BitcoindRpc {
     }
 }
 
+fn txid_from_sendrawtransaction_response(
+    tx: &str,
+    status: StatusCode,
+    text: &str,
+) -> Result<String, BitcoindRpcError> {
+    let resp = RpcResponse::decode(status, text)?;
+
+    if let Some(error) = resp.error.as_ref() {
+        if is_already_in_mempool_error(error) {
+            let txid = txid_from_transaction_hex(tx)?;
+            info!(
+                txid,
+                response = %text,
+                "transaction already in bitcoind mempool; prioritizing existing transaction"
+            );
+            return Ok(txid);
+        }
+
+        return Err(BitcoindRpcError::Rejected(format!(
+            "bitcoind RPC error: {error}"
+        )));
+    }
+
+    if !status.is_success() {
+        return Err(BitcoindRpcError::Other(format!(
+            "bitcoind HTTP {status}: {text}"
+        )));
+    }
+
+    resp.result
+        .and_then(|v| v.as_str().map(str::to_owned))
+        .ok_or_else(|| {
+            BitcoindRpcError::InvalidResponse("empty response from bitcoind".to_string())
+        })
+}
+
+fn txid_from_transaction_hex(tx: &str) -> Result<String, BitcoindRpcError> {
+    let transaction: Transaction = deserialize_hex(tx).map_err(|e| {
+        BitcoindRpcError::InvalidTransaction(format!("failed to decode transaction hex: {e}"))
+    })?;
+    Ok(transaction.compute_txid().to_string())
+}
+
 #[derive(Deserialize, Debug)]
 struct RpcResponse {
     result: Option<Value>,
@@ -192,6 +232,16 @@ fn validate_transaction_hex(tx: &str) -> Result<&str, BitcoindRpcError> {
     Ok(tx)
 }
 
+fn is_already_in_mempool_error(error: &Value) -> bool {
+    error
+        .get("message")
+        .and_then(Value::as_str)
+        .is_some_and(|message| {
+            let message = message.to_ascii_lowercase();
+            message.contains("already in mempool") || message.contains("txn-already-in-mempool")
+        })
+}
+
 fn is_not_in_mempool_error(error: &Value) -> bool {
     let code_is_not_found = error.get("code").and_then(Value::as_i64) == Some(-5);
     let message_says_not_in_mempool = error
@@ -204,8 +254,27 @@ fn is_not_in_mempool_error(error: &Value) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_not_in_mempool_error;
+    use super::{
+        is_already_in_mempool_error, is_not_in_mempool_error, txid_from_transaction_hex,
+        BitcoindRpc,
+    };
+    use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
     use serde_json::json;
+    use serde_json::Value;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+
+    const RAW_TX: &str = concat!(
+        "01000000",
+        "01",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "ffffffff",
+        "00",
+        "ffffffff",
+        "01",
+        "0000000000000000",
+        "00",
+        "00000000",
+    );
 
     #[test]
     fn detects_bitcoind_not_in_mempool_error() {
@@ -225,6 +294,128 @@ mod tests {
         });
 
         assert!(!is_not_in_mempool_error(&error));
+    }
+
+    #[test]
+    fn detects_bitcoind_already_in_mempool_error() {
+        let error = json!({
+            "code": -27,
+            "message": "txn-already-in-mempool"
+        });
+
+        assert!(is_already_in_mempool_error(&error));
+    }
+
+    #[test]
+    fn ignores_already_in_chain_error_for_mempool_detection() {
+        let error = json!({
+            "code": -27,
+            "message": "Transaction already in block chain"
+        });
+
+        assert!(!is_already_in_mempool_error(&error));
+    }
+
+    #[tokio::test]
+    async fn submit_transaction_prioritizes_when_tx_is_already_in_mempool() {
+        #[derive(Clone)]
+        struct MockBitcoindState {
+            requests: UnboundedSender<Value>,
+        }
+
+        async fn mock_bitcoind(
+            State(state): State<MockBitcoindState>,
+            Json(body): Json<Value>,
+        ) -> (StatusCode, Json<Value>) {
+            let method = body
+                .get("method")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            state
+                .requests
+                .send(body)
+                .expect("test should receive bitcoind request");
+
+            match method.as_deref() {
+                Some("sendrawtransaction") => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({
+                        "result": null,
+                        "error": {
+                            "code": -27,
+                            "message": "txn-already-in-mempool"
+                        },
+                        "id": "dmnd-client"
+                    })),
+                ),
+                Some("prioritisetransaction") => (
+                    StatusCode::OK,
+                    Json(json!({
+                        "result": true,
+                        "error": null,
+                        "id": "dmnd-client"
+                    })),
+                ),
+                _ => (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "result": null,
+                        "error": {
+                            "code": -32601,
+                            "message": "unknown method"
+                        },
+                        "id": "dmnd-client"
+                    })),
+                ),
+            }
+        }
+
+        let expected_txid = txid_from_transaction_hex(RAW_TX).expect("valid test transaction");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("test server local addr");
+        let (requests, mut received_requests) = unbounded_channel();
+        let app = Router::new()
+            .route("/", post(mock_bitcoind))
+            .with_state(MockBitcoindState { requests });
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+
+        let rpc = BitcoindRpc::new(
+            format!("http://{addr}"),
+            "user".to_string(),
+            "password".to_string(),
+            100_000_000,
+        );
+
+        let txid = rpc
+            .submit_transaction(RAW_TX)
+            .await
+            .expect("already-in-mempool tx should still be prioritized");
+
+        assert_eq!(txid, expected_txid);
+
+        let submit_request = received_requests
+            .recv()
+            .await
+            .expect("sendrawtransaction request");
+        assert_eq!(submit_request["method"], "sendrawtransaction");
+
+        let prioritize_request = received_requests
+            .recv()
+            .await
+            .expect("prioritisetransaction request");
+        assert_eq!(prioritize_request["method"], "prioritisetransaction");
+        assert_eq!(
+            prioritize_request["params"],
+            json!([expected_txid, 0, 100_000_000])
+        );
+
+        server.abort();
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -53,7 +53,7 @@ pub(crate) async fn start(
     };
     let app = AxumRouter::new()
         .route("/api/health", get(Api::health_check))
-        .route("/api/tx/{tx}", post(Api::send_tx_to_bitcoind))
+        .route("/api/tx/submit/{tx}", post(Api::send_tx_to_bitcoind))
         .route("/api/pool/info", get(Api::get_pool_info))
         .route("/api/stats/miners", get(Api::get_downstream_stats))
         .route("/api/stats/aggregate", get(Api::get_aggregate_stats))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-mod bitcoin_rpc;
+pub(crate) mod bitcoin_rpc;
 mod routes;
 pub mod stats;
 mod utils;
@@ -18,7 +18,13 @@ pub struct AppState {
     router: Router,
     stats_sender: StatsSender,
     downstream_handoff: crate::DownstreamHandoffSender,
-    rpc: Option<Arc<BitcoindRpc>>,
+    prioritizing_txs: Option<PrioritizingTxs>,
+}
+
+#[derive(Clone)]
+struct PrioritizingTxs {
+    rpc: Arc<BitcoindRpc>,
+    api_tx_token: String,
 }
 
 pub(crate) async fn start(
@@ -26,20 +32,24 @@ pub(crate) async fn start(
     stats_sender: StatsSender,
     downstream_handoff: crate::DownstreamHandoffSender,
 ) {
-    let rpc = Configuration::bitcoind_rpc_config().map(|config| {
-        Arc::new(BitcoindRpc::new(
+    let prioritizing_txs = Configuration::bitcoind_rpc_config().map(|config| {
+        let rpc = Arc::new(BitcoindRpc::new(
             config.url,
             config.user,
             config.pwd,
             config.fee_delta,
-        ))
+        ));
+        PrioritizingTxs {
+            rpc,
+            api_tx_token: config.api_tx_token,
+        }
     });
 
     let state = AppState {
         router,
         stats_sender,
         downstream_handoff,
-        rpc,
+        prioritizing_txs,
     };
     let app = AxumRouter::new()
         .route("/api/health", get(Api::health_check))

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -3,7 +3,7 @@ use crate::config::Configuration;
 use crate::proxy_state::ProxyState;
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{header::AUTHORIZATION, HeaderMap, StatusCode},
     response::IntoResponse,
     Json,
 };
@@ -154,9 +154,10 @@ impl Api {
 
     pub async fn send_tx_to_bitcoind(
         State(state): State<AppState>,
+        headers: HeaderMap,
         Path(tx): Path<String>,
     ) -> impl IntoResponse {
-        let Some(rpc) = state.rpc.as_ref() else {
+        let Some(prioritizing_txs) = state.prioritizing_txs.as_ref() else {
             warn!("PRIORITIZING TXS NOT ENABLED");
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -166,7 +167,15 @@ impl Api {
             );
         };
 
-        match rpc.submit_transaction(&tx).await {
+        if !is_authorized_for_tx_prioritization(&headers, &prioritizing_txs.api_tx_token) {
+            warn!("unauthorized tx prioritization request");
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(APIResponse::error(Some("Unauthorized".to_string()))),
+            );
+        }
+
+        match prioritizing_txs.rpc.submit_transaction(&tx).await {
             Ok(txid) => {
                 info!("transaction sent to bitcoind: {txid}");
                 (StatusCode::OK, Json(APIResponse::success(Some(txid))))
@@ -180,6 +189,14 @@ impl Api {
             }
         }
     }
+}
+
+fn is_authorized_for_tx_prioritization(headers: &HeaderMap, expected_token: &str) -> bool {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|token| token == expected_token)
 }
 
 #[derive(Serialize)]
@@ -242,14 +259,15 @@ async fn health_check_reports_full_translator_handoff() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
-        rpc: Some(std::sync::Arc::new(
-            crate::api::bitcoin_rpc::BitcoindRpc::new(
+        prioritizing_txs: Some(super::PrioritizingTxs {
+            rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
                 "http://127.0.0.1:8332".to_string(),
                 "user".to_string(),
                 "password".to_string(),
                 100_000_000,
-            ),
-        )),
+            )),
+            api_tx_token: "api-token".to_string(),
+        }),
     };
 
     let response = Api::health_check(State(state)).await.into_response();
@@ -271,12 +289,60 @@ async fn send_tx_reports_unavailable_when_rpc_is_disabled() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
-        rpc: None,
+        prioritizing_txs: None,
     };
 
-    let response = Api::send_tx_to_bitcoind(State(state), Path("00".to_string()))
-        .await
-        .into_response();
+    let response = Api::send_tx_to_bitcoind(
+        State(state),
+        axum::http::HeaderMap::new(),
+        Path("00".to_string()),
+    )
+    .await
+    .into_response();
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn send_tx_rejects_missing_api_tx_token_header() {
+    use axum::extract::{Path, State};
+    use axum::response::IntoResponse;
+    use tokio::sync::mpsc;
+
+    let auth_pub_k = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
+    let router = crate::router::Router::new(vec![], auth_pub_k, None, None);
+
+    let (handoff_tx, _handoff_rx) = mpsc::channel(1);
+    let state = AppState {
+        router,
+        stats_sender: crate::api::stats::StatsSender::new(),
+        downstream_handoff: handoff_tx,
+        prioritizing_txs: Some(super::PrioritizingTxs {
+            rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
+                "http://127.0.0.1:8332".to_string(),
+                "user".to_string(),
+                "password".to_string(),
+                100_000_000,
+            )),
+            api_tx_token: "api-token".to_string(),
+        }),
+    };
+
+    let response = Api::send_tx_to_bitcoind(
+        State(state),
+        axum::http::HeaderMap::new(),
+        Path("00".to_string()),
+    )
+    .await
+    .into_response();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn tx_prioritization_auth_accepts_matching_bearer_token() {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, "Bearer api-token".parse().unwrap());
+
+    assert!(is_authorized_for_tx_prioritization(&headers, "api-token"));
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,8 @@ struct Args {
     rpc_pwd: Option<String>,
     #[clap(long)]
     rpc_fee_delta: Option<i64>,
+    #[clap(long)]
+    api_tx_token: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -109,6 +111,7 @@ struct ConfigFile {
     rpc_user: Option<String>,
     rpc_pwd: Option<String>,
     rpc_fee_delta: Option<i64>,
+    api_tx_token: Option<String>,
 }
 
 impl ConfigFile {
@@ -140,6 +143,7 @@ impl ConfigFile {
             rpc_user: None,
             rpc_pwd: None,
             rpc_fee_delta: None,
+            api_tx_token: None,
         }
     }
 }
@@ -180,6 +184,7 @@ pub(crate) struct BitcoindRpcConfig {
     pub user: String,
     pub pwd: String,
     pub fee_delta: i64,
+    pub api_tx_token: String,
 }
 
 impl Configuration {
@@ -232,13 +237,20 @@ and make that test pass."
         rpc_user: String,
         rpc_pwd: String,
         rpc_fee_delta: String,
+        api_tx_token: String,
     ) -> Self {
         if let Err(error) = Self::validate_supported_delay(delay) {
             panic!("{error}");
         }
 
         let (prioritizing_txs_config, missing_prioritizing_txs_variables) =
-            Self::build_prioritizing_txs_config(rpc_url, rpc_user, rpc_pwd, rpc_fee_delta);
+            Self::build_prioritizing_txs_config(
+                rpc_url,
+                rpc_user,
+                rpc_pwd,
+                rpc_fee_delta,
+                api_tx_token,
+            );
 
         Configuration {
             token,
@@ -275,6 +287,7 @@ and make that test pass."
         user: String,
         pwd: String,
         fee_delta: String,
+        api_tx_token: String,
     ) -> (Option<BitcoindRpcConfig>, Vec<&'static str>) {
         let mut missing = Vec::new();
         if url.trim().is_empty() {
@@ -288,6 +301,9 @@ and make that test pass."
         }
         if fee_delta.trim().is_empty() {
             missing.push("RPC_FEE_DELTA");
+        }
+        if api_tx_token.trim().is_empty() {
+            missing.push("API_TX_TOKEN");
         }
 
         if !missing.is_empty() {
@@ -305,6 +321,7 @@ and make that test pass."
                 user,
                 pwd,
                 fee_delta,
+                api_tx_token,
             }),
             missing,
         )
@@ -347,6 +364,7 @@ and make that test pass."
             "user".to_string(),
             "password".to_string(),
             "100000000".to_string(),
+            "api-token".to_string(),
         )
     }
 
@@ -528,7 +546,7 @@ and make that test pass."
             return;
         }
 
-        if missing.len() == 4 {
+        if missing.len() == 5 {
             warn!("PRIORITIZING TXS NOT ENABLED");
         } else {
             error!(
@@ -606,6 +624,11 @@ and make that test pass."
             .map(|value| value.to_string())
             .or_else(|| config.rpc_fee_delta.map(|value| value.to_string()))
             .or_else(|| std::env::var("RPC_FEE_DELTA").ok())
+            .unwrap_or_default();
+        let api_tx_token = args
+            .api_tx_token
+            .or(config.api_tx_token)
+            .or_else(|| std::env::var("API_TX_TOKEN").ok())
             .unwrap_or_default();
         if let Some(ref miner_name) = miner_name {
             validate_miner_name(miner_name).unwrap_or_else(|e| panic!("{e}"));
@@ -780,6 +803,7 @@ and make that test pass."
             rpc_user,
             rpc_pwd,
             rpc_fee_delta,
+            api_tx_token,
         )
     }
 }
@@ -968,6 +992,7 @@ mod tests {
             "user".to_string(),
             "password".to_string(),
             "42".to_string(),
+            "api-token".to_string(),
         );
 
         assert!(missing.is_empty());
@@ -978,10 +1003,22 @@ mod tests {
             "".to_string(),
             "password".to_string(),
             "42".to_string(),
+            "api-token".to_string(),
         );
 
         assert!(config.is_none());
         assert_eq!(missing, vec!["RPC_USER"]);
+
+        let (config, missing) = Configuration::build_prioritizing_txs_config(
+            "http://127.0.0.1:8332".to_string(),
+            "user".to_string(),
+            "password".to_string(),
+            "42".to_string(),
+            "".to_string(),
+        );
+
+        assert!(config.is_none());
+        assert_eq!(missing, vec!["API_TX_TOKEN"]);
     }
 
     #[test]
@@ -991,12 +1028,19 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            "".to_string(),
         );
 
         assert!(config.is_none());
         assert_eq!(
             missing,
-            vec!["RPC_URL", "RPC_USER", "RPC_PWD", "RPC_FEE_DELTA"]
+            vec![
+                "RPC_URL",
+                "RPC_USER",
+                "RPC_PWD",
+                "RPC_FEE_DELTA",
+                "API_TX_TOKEN"
+            ]
         );
     }
 }

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use task_manager::TaskManager;
 use tokio::sync::mpsc::{Receiver as TReceiver, Sender as TSender};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use async_recursion::async_recursion;
 use nohash_hasher::BuildNoHashHasher;
@@ -266,12 +266,12 @@ impl JobDeclarator {
                 }
             }
         }
-        for txid in missing_prioritized_txids(&prioritized_txids, &template_txids) {
-            error!(
-                txid,
-                template_id = template.template_id,
-                "prioritized transaction is missing from template transaction list"
-            );
+        let missing_txids = missing_prioritized_txids(&prioritized_txids, &template_txids);
+        if !missing_txids.is_empty() {
+            tokio::task::spawn(check_missing_prioritized_txids(
+                missing_txids,
+                template.template_id,
+            ));
         }
         let tx_ids: Seq064K<'static, U256> = Seq064K::from(tx_ids);
 
@@ -605,6 +605,46 @@ fn missing_prioritized_txids(
         .filter(|txid| !template_txids.contains(*txid))
         .cloned()
         .collect()
+}
+
+// Prioritized transactions are submitted to bitcoind with a large virtual fee delta so they
+// should remain attractive for block templates while they are in the mempool. If such a
+// transaction is missing from a template, check getmempoolentry before logging an error: when
+// bitcoind no longer has it in the mempool, the most likely explanation is that it was mined.
+async fn check_missing_prioritized_txids(missing_txids: Vec<String>, template_id: u64) {
+    let Some(config) = crate::Configuration::bitcoind_rpc_config() else {
+        return;
+    };
+
+    let rpc = crate::api::bitcoin_rpc::BitcoindRpc::new(
+        config.url,
+        config.user,
+        config.pwd,
+        config.fee_delta,
+    );
+
+    for txid in missing_txids {
+        match rpc.transaction_in_mempool(&txid).await {
+            Ok(true) => {
+                error!(
+                    txid,
+                    template_id,
+                    "prioritized transaction is in mempool but missing from template transaction list"
+                );
+            }
+            Ok(false) => {
+                crate::prioritized_transactions::remove(&txid);
+            }
+            Err(e) => {
+                warn!(
+                    txid,
+                    template_id,
+                    error = %e,
+                    "failed to check prioritized transaction mempool state"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/prioritized_transactions.rs
+++ b/src/prioritized_transactions.rs
@@ -24,3 +24,10 @@ pub(crate) fn snapshot() -> Vec<String> {
         .cloned()
         .collect()
 }
+
+pub(crate) fn remove(txid: &str) {
+    txids()
+        .lock()
+        .expect("prioritized transactions mutex poisoned")
+        .remove(txid);
+}

--- a/tests/library_init.rs
+++ b/tests/library_init.rs
@@ -150,6 +150,7 @@ async fn library_init_sv2_setup_connection() {
         "user".to_string(),
         "password".to_string(),
         "100000000".to_string(),
+        "api-token".to_string(),
     );
 
     let proxy = tokio::spawn(dmnd_client::start(config));


### PR DESCRIPTION
After [PR254](https://github.com/dmnd-pool/dmnd-client/pull/254) and [PR257](https://github.com/dmnd-pool/dmnd-client/pull/257), this should fix all the issues encountered so far with priotised txs feature.
Fixes [issue 255](https://github.com/dmnd-pool/dmnd-client/issues/255)

Abstract
Require a dedicated API_TX_TOKEN bearer credential before POST /api/tx/{tx} can submit and prioritize transactions through bitcoind. Treat the token as part of the prioritizing-txs configuration gate, so the endpoint is available only when RPC_URL, RPC_USER, RPC_PWD, RPC_FEE_DELTA, and API_TX_TOKEN are all set.

Keep disabled prioritization returning the existing 503 response, and reject missing or invalid endpoint credentials with 401 before any Bitcoin RPC is attempted. Store the API token alongside the BitcoindRpc state used by the API server instead of leaving the write path unauthenticated.

When prioritized transactions disappear from new templates, check bitcoind mempool state in the background before reporting an error. Remove txids that are no longer in the mempool, warn on mempool-check failures, and only log a template error when bitcoind still reports the transaction as mempool-resident.

Add regression coverage for disabled prioritization config, unauthorized tx requests, bearer-token acceptance, missing API_TX_TOKEN config, and bitcoind not-in-mempool error classification.