### PR TITLE
Expose prioritized transaction details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.3.15"
+version = "0.3.17"
 dependencies = [
  "async-recursion",
  "axum",

--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ Example:
       -H "Authorization: Bearer <api-token>" \
       "http://127.0.0.1:3001/api/tx/prioritized"
 
+The prioritized transactions response includes the tracked transaction count, transaction hex,
+and live mempool fees from Bitcoin Core. `tx_fee.real` is `getmempoolentry`'s `fees.base`;
+`tx_fee.modified` is `getmempoolentry`'s boosted `fees.modified`.
+
+    {
+      "success": true,
+      "message": null,
+      "data": {
+        "count": 1,
+        "txs": [
+          {
+            "txid": "<txid>",
+            "tx_hex": "<raw-transaction-hex>",
+            "tx_fee": {
+              "real": 0.00001000,
+              "modified": 1.00001000
+            }
+          }
+        ]
+      }
+    }
+
 If the prioritization configuration is incomplete, these endpoints are disabled. In that case the
 client logs that transaction prioritization is not enabled and the endpoints return `503 Service
 Unavailable`.

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -1,5 +1,5 @@
 use axum::http::StatusCode;
-use bitcoin::{blockdata::transaction::Transaction, consensus::encode::deserialize_hex};
+use bitcoin::{blockdata::transaction::Transaction, consensus::encode::deserialize_hex, Txid};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{error::Error as StdError, fmt, time::Duration};
@@ -27,19 +27,30 @@ impl BitcoindRpc {
 
     pub(crate) async fn submit_transaction(&self, tx: &str) -> Result<String, BitcoindRpcError> {
         let tx = validate_transaction_hex(tx)?;
+        let transaction = transaction_from_hex(tx)?;
         let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
-        let txid = txid_from_sendrawtransaction_response(tx, status, &text)?;
+        let txid = txid_from_sendrawtransaction_response(&transaction, status, &text)?;
+        let computed_txid = transaction.compute_txid();
+        if txid != computed_txid {
+            return Err(BitcoindRpcError::InvalidResponse(format!(
+                "bitcoind returned txid {txid}, but transaction hex decodes to {computed_txid}"
+            )));
+        }
+
         self.prioritise_transaction(&txid).await?;
-        crate::prioritized_transactions::record(&txid);
-        Ok(txid)
+        crate::prioritized_transactions::record(transaction);
+        Ok(txid.to_string())
     }
 
-    async fn prioritise_transaction(&self, txid: &str) -> Result<(), BitcoindRpcError> {
+    async fn prioritise_transaction(&self, txid: &Txid) -> Result<(), BitcoindRpcError> {
         let (status, text) = self
-            .send_request("prioritisetransaction", json!([txid, 0, self.fee_delta]))
+            .send_request(
+                "prioritisetransaction",
+                json!([txid.to_string(), 0, self.fee_delta]),
+            )
             .await?;
         info!(
-            txid,
+            txid = %txid,
             fee_delta = self.fee_delta,
             %status,
             response = %text,
@@ -64,13 +75,47 @@ impl BitcoindRpc {
         &self,
         txid: &str,
     ) -> Result<bool, BitcoindRpcError> {
+        Ok(self.get_mempool_entry(txid).await?.is_some())
+    }
+
+    pub(crate) async fn mempool_entry_fees(
+        &self,
+        txid: &Txid,
+    ) -> Result<Option<(f64, f64)>, BitcoindRpcError> {
+        let Some(result) = self.get_mempool_entry(&txid.to_string()).await? else {
+            return Ok(None);
+        };
+
+        let fees = result.get("fees").ok_or_else(|| {
+            BitcoindRpcError::InvalidResponse(format!(
+                "missing fees in getmempoolentry response from bitcoind: {result}"
+            ))
+        })?;
+        let real_fee = fees.get("base").and_then(Value::as_f64).ok_or_else(|| {
+            BitcoindRpcError::InvalidResponse(format!(
+                "missing fees.base in getmempoolentry response from bitcoind: {result}"
+            ))
+        })?;
+        let modified_fee = fees
+            .get("modified")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| {
+                BitcoindRpcError::InvalidResponse(format!(
+                    "missing fees.modified in getmempoolentry response from bitcoind: {result}"
+                ))
+            })?;
+
+        Ok(Some((real_fee, modified_fee)))
+    }
+
+    async fn get_mempool_entry(&self, txid: &str) -> Result<Option<Value>, BitcoindRpcError> {
         let txid = validate_transaction_hex(txid)?;
         let (status, text) = self.send_request("getmempoolentry", json!([txid])).await?;
         let resp = RpcResponse::decode(status, &text)?;
 
         if let Some(error) = resp.error {
             if is_not_in_mempool_error(&error) {
-                return Ok(false);
+                return Ok(None);
             }
 
             return Err(BitcoindRpcError::Other(format!(
@@ -85,7 +130,7 @@ impl BitcoindRpc {
         }
 
         match resp.result {
-            Some(Value::Object(_)) => Ok(true),
+            Some(result @ Value::Object(_)) => Ok(Some(result)),
             _ => Err(BitcoindRpcError::InvalidResponse(format!(
                 "invalid getmempoolentry response from bitcoind: {text}"
             ))),
@@ -133,17 +178,17 @@ impl BitcoindRpc {
 }
 
 fn txid_from_sendrawtransaction_response(
-    tx: &str,
+    transaction: &Transaction,
     status: StatusCode,
     text: &str,
-) -> Result<String, BitcoindRpcError> {
+) -> Result<Txid, BitcoindRpcError> {
     let resp = RpcResponse::decode(status, text)?;
 
     if let Some(error) = resp.error.as_ref() {
         if is_already_in_mempool_error(error) {
-            let txid = txid_from_transaction_hex(tx)?;
+            let txid = transaction.compute_txid();
             info!(
-                txid,
+                txid = %txid,
                 response = %text,
                 "transaction already in bitcoind mempool; prioritizing existing transaction"
             );
@@ -165,14 +210,15 @@ fn txid_from_sendrawtransaction_response(
         .and_then(|v| v.as_str().map(str::to_owned))
         .ok_or_else(|| {
             BitcoindRpcError::InvalidResponse("empty response from bitcoind".to_string())
-        })
+        })?
+        .parse::<Txid>()
+        .map_err(|e| BitcoindRpcError::InvalidResponse(format!("invalid txid from bitcoind: {e}")))
 }
 
-fn txid_from_transaction_hex(tx: &str) -> Result<String, BitcoindRpcError> {
-    let transaction: Transaction = deserialize_hex(tx).map_err(|e| {
+fn transaction_from_hex(tx: &str) -> Result<Transaction, BitcoindRpcError> {
+    deserialize_hex(tx).map_err(|e| {
         BitcoindRpcError::InvalidTransaction(format!("failed to decode transaction hex: {e}"))
-    })?;
-    Ok(transaction.compute_txid().to_string())
+    })
 }
 
 #[derive(Deserialize, Debug)]
@@ -255,8 +301,7 @@ fn is_not_in_mempool_error(error: &Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_already_in_mempool_error, is_not_in_mempool_error, txid_from_transaction_hex,
-        BitcoindRpc,
+        is_already_in_mempool_error, is_not_in_mempool_error, transaction_from_hex, BitcoindRpc,
     };
     use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
     use serde_json::json;
@@ -370,7 +415,9 @@ mod tests {
             }
         }
 
-        let expected_txid = txid_from_transaction_hex(RAW_TX).expect("valid test transaction");
+        let expected_txid = transaction_from_hex(RAW_TX)
+            .expect("valid test transaction")
+            .compute_txid();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("test server should bind");
@@ -397,7 +444,7 @@ mod tests {
             .await
             .expect("already-in-mempool tx should still be prioritized");
 
-        assert_eq!(txid, expected_txid);
+        assert_eq!(txid, expected_txid.to_string());
 
         let submit_request = received_requests
             .recv()

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -7,7 +7,9 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use bitcoin::consensus::encode::serialize_hex;
 use serde::Serialize;
+use serde_json::json;
 use tracing::{error, info, warn};
 
 pub struct Api {}
@@ -200,7 +202,7 @@ impl Api {
             warn!("PRIORITIZING TXS NOT ENABLED");
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
-                Json(APIResponse::<PrioritizedTransactions>::error(Some(
+                Json(APIResponse::<serde_json::Value>::error(Some(
                     "PRIORITIZING TXS NOT ENABLED".to_string(),
                 ))),
             );
@@ -210,20 +212,60 @@ impl Api {
             warn!("unauthorized prioritized txs request");
             return (
                 StatusCode::UNAUTHORIZED,
-                Json(APIResponse::<PrioritizedTransactions>::error(Some(
+                Json(APIResponse::<serde_json::Value>::error(Some(
                     "Unauthorized".to_string(),
                 ))),
             );
         }
 
-        let mut txids = crate::prioritized_transactions::snapshot();
-        txids.sort();
-        let response = PrioritizedTransactions {
-            count: txids.len(),
-            txids,
-        };
+        let mut txs = Vec::new();
+        for (txid, transaction) in crate::prioritized_transactions::snapshot() {
+            let Some((real_fee, modified_fee)) = (match prioritizing_txs
+                .rpc
+                .mempool_entry_fees(&txid)
+                .await
+            {
+                Ok(fees) => fees,
+                Err(e) => {
+                    error!(txid = %txid, error = %e, "failed to fetch prioritized transaction mempool fees");
+                    return (
+                        e.status_code(),
+                        Json(APIResponse::<serde_json::Value>::error(Some(e.to_string()))),
+                    );
+                }
+            }) else {
+                info!(
+                    txid = %txid,
+                    "tracked prioritized transaction is no longer in mempool; removing it"
+                );
+                crate::prioritized_transactions::remove(&txid);
+                continue;
+            };
 
-        (StatusCode::OK, Json(APIResponse::success(Some(response))))
+            let txid = txid.to_string();
+            txs.push((
+                txid.clone(),
+                json!({
+                    "txid": txid,
+                    "tx_hex": serialize_hex(&transaction),
+                    "tx_fee": {
+                        "real": real_fee,
+                        "modified": modified_fee
+                    }
+                }),
+            ));
+        }
+        txs.sort_by(|a, b| a.0.cmp(&b.0));
+        let txs: Vec<serde_json::Value> = txs.into_iter().map(|(_, tx)| tx).collect();
+        let response = json!({
+            "count": txs.len(),
+            "txs": txs
+        });
+
+        (
+            StatusCode::OK,
+            Json(APIResponse::<serde_json::Value>::success(Some(response))),
+        )
     }
 }
 
@@ -242,12 +284,6 @@ struct AggregateStates {
     aggregate_accepted_shares: u64,
     aggregate_rejected_shares: u64,
     aggregate_diff: f64,
-}
-
-#[derive(Serialize)]
-struct PrioritizedTransactions {
-    count: usize,
-    txids: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -386,10 +422,122 @@ async fn get_prioritized_transactions_returns_snapshot() {
     use axum::body::to_bytes;
     use axum::extract::State;
     use axum::response::IntoResponse;
+    use axum::{routing::post, Json, Router};
+    use bitcoin::{
+        blockdata::transaction::Transaction,
+        consensus::encode::{deserialize_hex, serialize_hex},
+    };
+    use serde_json::{json, Value};
+    use std::{collections::HashMap, sync::Arc};
     use tokio::sync::mpsc;
 
-    crate::prioritized_transactions::record("routes-test-prioritized-a");
-    crate::prioritized_transactions::record("routes-test-prioritized-b");
+    #[derive(Clone)]
+    struct MockBitcoindState {
+        fees: Arc<HashMap<String, (f64, f64)>>,
+    }
+
+    async fn mock_bitcoind(
+        State(state): State<MockBitcoindState>,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        let method = body
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+
+        match method.as_deref() {
+            Some("getmempoolentry") => {
+                let txid = body
+                    .get("params")
+                    .and_then(Value::as_array)
+                    .and_then(|params| params.first())
+                    .and_then(Value::as_str)
+                    .expect("getmempoolentry txid param");
+                let (real_fee, modified_fee) = state
+                    .fees
+                    .get(txid)
+                    .copied()
+                    .unwrap_or((0.000_010_00, 1.000_010_00));
+
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "result": {
+                            "fees": {
+                                "base": real_fee,
+                                "modified": modified_fee
+                            }
+                        },
+                        "error": null,
+                        "id": "dmnd-client"
+                    })),
+                )
+            }
+            _ => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "result": null,
+                    "error": {
+                        "code": -32601,
+                        "message": "unknown method"
+                    },
+                    "id": "dmnd-client"
+                })),
+            ),
+        }
+    }
+
+    const RAW_TX_A: &str = concat!(
+        "01000000",
+        "01",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "ffffffff",
+        "00",
+        "ffffffff",
+        "01",
+        "0000000000000000",
+        "00",
+        "00000000",
+    );
+    const RAW_TX_B: &str = concat!(
+        "02000000",
+        "01",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "ffffffff",
+        "00",
+        "ffffffff",
+        "01",
+        "0000000000000000",
+        "00",
+        "00000000",
+    );
+
+    let tx_a: Transaction = deserialize_hex(RAW_TX_A).expect("valid test transaction");
+    let tx_b: Transaction = deserialize_hex(RAW_TX_B).expect("valid test transaction");
+    let txid_a = tx_a.compute_txid().to_string();
+    let txid_b = tx_b.compute_txid().to_string();
+    let tx_hex_a = serialize_hex(&tx_a);
+    let tx_hex_b = serialize_hex(&tx_b);
+    let fees = Arc::new(HashMap::from([
+        (txid_a.clone(), (0.000_010_00, 1.000_010_00)),
+        (txid_b.clone(), (0.000_020_00, 1.000_020_00)),
+    ]));
+
+    crate::prioritized_transactions::record(tx_a);
+    crate::prioritized_transactions::record(tx_b);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test server should bind");
+    let addr = listener.local_addr().expect("test server local addr");
+    let app = Router::new()
+        .route("/", post(mock_bitcoind))
+        .with_state(MockBitcoindState { fees });
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("test server should run");
+    });
 
     let auth_pub_k = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
     let router = crate::router::Router::new(vec![], auth_pub_k, None, None);
@@ -401,7 +549,7 @@ async fn get_prioritized_transactions_returns_snapshot() {
         downstream_handoff: handoff_tx,
         prioritizing_txs: Some(super::PrioritizingTxs {
             rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
-                "http://127.0.0.1:8332".to_string(),
+                format!("http://{addr}"),
                 "user".to_string(),
                 "password".to_string(),
                 100_000_000,
@@ -421,15 +569,26 @@ async fn get_prioritized_transactions_returns_snapshot() {
 
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let txids = body["data"]["txids"].as_array().unwrap();
+    let txs = body["data"]["txs"].as_array().unwrap();
+    let tx_a = txs
+        .iter()
+        .find(|tx| tx["txid"].as_str() == Some(txid_a.as_str()))
+        .expect("first prioritized transaction should be present");
+    let tx_b = txs
+        .iter()
+        .find(|tx| tx["txid"].as_str() == Some(txid_b.as_str()))
+        .expect("second prioritized transaction should be present");
 
     assert_eq!(body["success"], true);
-    assert!(txids
-        .iter()
-        .any(|txid| txid.as_str() == Some("routes-test-prioritized-a")));
-    assert!(txids
-        .iter()
-        .any(|txid| txid.as_str() == Some("routes-test-prioritized-b")));
+    assert_eq!(body["data"]["count"].as_u64(), Some(txs.len() as u64));
+    assert_eq!(tx_a["tx_fee"]["real"], 0.000_010_00);
+    assert_eq!(tx_a["tx_fee"]["modified"], 1.000_010_00);
+    assert_eq!(tx_a["tx_hex"], tx_hex_a);
+    assert_eq!(tx_b["tx_fee"]["real"], 0.000_020_00);
+    assert_eq!(tx_b["tx_fee"]["modified"], 1.000_020_00);
+    assert_eq!(tx_b["tx_hex"], tx_hex_b);
+
+    server.abort();
 }
 
 #[test]

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -1,7 +1,7 @@
 pub mod message_handler;
 mod task_manager;
 use binary_sv2::{Seq0255, Seq064K, B016M, B064K, U256};
-use bitcoin::{blockdata::transaction::Transaction, hashes::Hash};
+use bitcoin::{blockdata::transaction::Transaction, hashes::Hash, Txid};
 use codec_sv2::{HandshakeRole, Initiator, StandardEitherFrame, StandardSv2Frame};
 use demand_sv2_connection::noise_connection_tokio::Connection;
 use roles_logic_sv2::{
@@ -246,7 +246,7 @@ impl JobDeclarator {
             .map_err(|_| Error::JobDeclaratorMutexCorrupted)?;
 
         let template_transactions = tx_list_.to_vec();
-        let prioritized_txids = crate::prioritized_transactions::snapshot();
+        let prioritized_txids = crate::prioritized_transactions::snapshot_txids();
         let mut template_txids = HashSet::with_capacity(template_transactions.len());
         let mut tx_list: Vec<Transaction> = Vec::new();
         let mut tx_ids = vec![];
@@ -255,7 +255,7 @@ impl JobDeclarator {
                 bitcoin::consensus::deserialize(&tx);
             match transaction {
                 Ok(tx) => {
-                    template_txids.insert(tx.compute_txid().to_string());
+                    template_txids.insert(tx.compute_txid());
                     let w_tx_id: U256 = tx.compute_wtxid().to_raw_hash().to_byte_array().into();
                     tx_list.push(tx);
                     tx_ids.push(w_tx_id);
@@ -597,13 +597,13 @@ impl JobDeclarator {
 }
 
 fn missing_prioritized_txids(
-    prioritized_txids: &[String],
-    template_txids: &HashSet<String>,
-) -> Vec<String> {
+    prioritized_txids: &[Txid],
+    template_txids: &HashSet<Txid>,
+) -> Vec<Txid> {
     prioritized_txids
         .iter()
         .filter(|txid| !template_txids.contains(*txid))
-        .cloned()
+        .copied()
         .collect()
 }
 
@@ -611,7 +611,7 @@ fn missing_prioritized_txids(
 // should remain attractive for block templates while they are in the mempool. If such a
 // transaction is missing from a template, check getmempoolentry before logging an error: when
 // bitcoind no longer has it in the mempool, the most likely explanation is that it was mined.
-async fn check_missing_prioritized_txids(missing_txids: Vec<String>, template_id: u64) {
+async fn check_missing_prioritized_txids(missing_txids: Vec<Txid>, template_id: u64) {
     let Some(config) = crate::Configuration::bitcoind_rpc_config() else {
         return;
     };
@@ -624,10 +624,10 @@ async fn check_missing_prioritized_txids(missing_txids: Vec<String>, template_id
     );
 
     for txid in missing_txids {
-        match rpc.transaction_in_mempool(&txid).await {
+        match rpc.transaction_in_mempool(&txid.to_string()).await {
             Ok(true) => {
                 error!(
-                    txid,
+                    txid = %txid,
                     template_id,
                     "prioritized transaction is in mempool but missing from template transaction list"
                 );
@@ -637,7 +637,7 @@ async fn check_missing_prioritized_txids(missing_txids: Vec<String>, template_id
             }
             Err(e) => {
                 warn!(
-                    txid,
+                    txid = %txid,
                     template_id,
                     error = %e,
                     "failed to check prioritized transaction mempool state"
@@ -650,24 +650,32 @@ async fn check_missing_prioritized_txids(missing_txids: Vec<String>, template_id
 #[cfg(test)]
 mod tests {
     use super::missing_prioritized_txids;
+    use bitcoin::Txid;
     use std::collections::HashSet;
+
+    fn txid(value: u8) -> Txid {
+        format!("{value:064x}").parse().expect("valid txid")
+    }
 
     #[test]
     fn no_missing_prioritized_txids_when_all_are_in_template() {
-        let prioritized = vec!["a".to_string(), "b".to_string()];
-        let template = HashSet::from(["a".to_string(), "b".to_string(), "c".to_string()]);
+        let a = txid(1);
+        let b = txid(2);
+        let c = txid(3);
+        let prioritized = vec![a, b];
+        let template = HashSet::from([a, b, c]);
 
         assert!(missing_prioritized_txids(&prioritized, &template).is_empty());
     }
 
     #[test]
     fn returns_only_prioritized_txids_missing_from_template() {
-        let prioritized = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-        let template = HashSet::from(["a".to_string(), "c".to_string()]);
+        let a = txid(1);
+        let b = txid(2);
+        let c = txid(3);
+        let prioritized = vec![a, b, c];
+        let template = HashSet::from([a, c]);
 
-        assert_eq!(
-            missing_prioritized_txids(&prioritized, &template),
-            vec!["b".to_string()]
-        );
+        assert_eq!(missing_prioritized_txids(&prioritized, &template), vec![b]);
     }
 }

--- a/src/prioritized_transactions.rs
+++ b/src/prioritized_transactions.rs
@@ -1,32 +1,44 @@
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     sync::{Mutex, OnceLock},
 };
 
-static PRIORITIZED_TXIDS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+use bitcoin::{blockdata::transaction::Transaction, Txid};
 
-fn txids() -> &'static Mutex<HashSet<String>> {
-    PRIORITIZED_TXIDS.get_or_init(|| Mutex::new(HashSet::new()))
+static PRIORITIZED_TRANSACTIONS: OnceLock<Mutex<HashMap<Txid, Transaction>>> = OnceLock::new();
+
+fn transactions() -> &'static Mutex<HashMap<Txid, Transaction>> {
+    PRIORITIZED_TRANSACTIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub(crate) fn record(txid: &str) {
-    txids()
+pub(crate) fn record(transaction: Transaction) {
+    let txid = transaction.compute_txid();
+    transactions()
         .lock()
         .expect("prioritized transactions mutex poisoned")
-        .insert(txid.to_string());
+        .insert(txid, transaction);
 }
 
-pub(crate) fn snapshot() -> Vec<String> {
-    txids()
+pub(crate) fn snapshot() -> Vec<(Txid, Transaction)> {
+    transactions()
         .lock()
         .expect("prioritized transactions mutex poisoned")
         .iter()
-        .cloned()
+        .map(|(txid, transaction)| (*txid, transaction.clone()))
         .collect()
 }
 
-pub(crate) fn remove(txid: &str) {
-    txids()
+pub(crate) fn snapshot_txids() -> Vec<Txid> {
+    transactions()
+        .lock()
+        .expect("prioritized transactions mutex poisoned")
+        .keys()
+        .copied()
+        .collect()
+}
+
+pub(crate) fn remove(txid: &Txid) {
+    transactions()
         .lock()
         .expect("prioritized transactions mutex poisoned")
         .remove(txid);


### PR DESCRIPTION
Return the prioritized transaction snapshot from
GET /api/tx/prioritized with a count, raw
transaction hex, and live mempool fee data.

Store prioritized transactions internally as
Txid to Transaction so the API can render hex
without stringly typed state.

Fetch getmempoolentry for each tracked transaction and report fees.base as tx_fee.real plus
fees.modified as tx_fee.modified.

Remove tracked entries that are no longer in the
mempool while preserving the existing bearer-token authorization and unavailable behavior.

Document the response and cover the route with
mocked bitcoind fee data.