### PR TITLE
FIX worker telemetry to report downstream-accepted hashrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "dmnd-client"
-version = "0.3.17"
+version = "0.3.22"
 dependencies = [
  "async-recursion",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmnd-client"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2021"
 
 [lib]

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -569,27 +569,31 @@ impl Downstream {
         Ok(())
     }
 
-    fn spawn_submit_accounting(
-        self_: Arc<Mutex<Self>>,
-        response_rx: SubmitShareResultReceiver,
+    fn record_downstream_valid_share(
+        &self,
         worker_name: String,
         difficulty: f32,
         job_id: i64,
         nonce: i64,
-        request_job_id: String,
     ) {
+        let share = ShareInfo::new(worker_name, Some(difficulty), job_id, nonce, None);
+        self.share_monitor.insert_share(share);
+        self.stats_sender.update_accepted_shares(self.connection_id);
+    }
+
+    fn spawn_submit_accounting(
+        response_rx: SubmitShareResultReceiver,
+        difficulty: f32,
+        request_job_id: String,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let submit_result = match response_rx.await {
                 Ok(result) => result,
                 Err(_) => Err(RejectionReason::UpstreamRejected),
             };
 
-            let accounting_result = self_.safe_lock(|s| match submit_result {
+            match submit_result {
                 Ok(()) => {
-                    let share =
-                        ShareInfo::new(worker_name.clone(), Some(difficulty), job_id, nonce, None);
-                    s.share_monitor.insert_share(share);
-                    s.stats_sender.update_accepted_shares(s.connection_id);
                     if share_log_enabled() {
                         info!(
                             "Share for Job {} and difficulty {} is accepted upstream",
@@ -598,10 +602,6 @@ impl Downstream {
                     }
                 }
                 Err(reason) => {
-                    let share =
-                        ShareInfo::new(worker_name.clone(), None, job_id, nonce, Some(reason));
-                    s.share_monitor.insert_share(share);
-                    s.stats_sender.update_rejected_shares(s.connection_id);
                     if share_log_enabled() {
                         info!(
                             "Share for Job {} and difficulty {} was rejected with {:?}",
@@ -609,13 +609,8 @@ impl Downstream {
                         );
                     }
                 }
-            });
-
-            if let Err(e) = accounting_result {
-                error!("Failed to finalize submit accounting: {e}");
-                ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
             }
-        });
+        })
     }
 
     async fn handle_submit_request(
@@ -717,15 +712,19 @@ impl Downstream {
 
         match Self::forward_submit_share(&self_, upstream_request).await {
             Ok(response_rx) => {
-                Self::spawn_submit_accounting(
-                    self_.clone(),
+                self_.safe_lock(|s| {
+                    s.record_downstream_valid_share(
+                        request.user_name.clone(),
+                        job.difficulty,
+                        job_id,
+                        nonce,
+                    )
+                })?;
+                std::mem::drop(Self::spawn_submit_accounting(
                     response_rx,
-                    request.user_name.clone(),
                     job.difficulty,
-                    job_id,
-                    nonce,
                     request.job_id.clone(),
-                );
+                ));
                 self_.safe_lock(|s| s.submit_counts_for_diff.set(true))?;
                 Self::send_message_downstream(self_, request.respond(true).into()).await;
             }
@@ -1395,6 +1394,38 @@ mod tests {
             .safe_lock(|d| d.difficulty_mgmt.submits.len())
             .unwrap();
         assert_eq!(counted_shares, 0);
+    }
+
+    #[tokio::test]
+    async fn upstream_rejection_after_downstream_accept_does_not_invalidate_worker_summary() {
+        let (downstream, _rx_outgoing, stats_sender) =
+            test_downstream(vec!["worker".to_string()], 4, None).await;
+        let token = downstream
+            .safe_lock(|d| d.token.safe_lock(|t| t.clone()).unwrap())
+            .unwrap();
+        let previous_totals = MonitorAPI::worker_summary_totals(&token, "worker").unwrap_or((0, 0));
+
+        downstream
+            .safe_lock(|d| {
+                d.record_downstream_valid_share("worker".to_string(), 1.0, 42, 11);
+            })
+            .unwrap();
+
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let handle = Downstream::spawn_submit_accounting(result_rx, 1.0, "42".to_string());
+        result_tx
+            .send(Err(RejectionReason::UpstreamRejected))
+            .unwrap();
+        handle.await.unwrap();
+
+        assert_eq!(
+            MonitorAPI::worker_summary_totals(&token, "worker"),
+            Some((previous_totals.0 + 1, previous_totals.1))
+        );
+
+        let stats = stats_sender.collect_stats().await.unwrap();
+        assert_eq!(stats.get(&1).unwrap().accepted_shares, 1);
+        assert_eq!(stats.get(&1).unwrap().rejected_shares, 0);
     }
 
     #[tokio::test]

--- a/src/translator/upstream/upstream.rs
+++ b/src/translator/upstream/upstream.rs
@@ -462,12 +462,27 @@ impl Upstream {
             return;
         }
 
-        let acknowledged_sequences: Vec<u32> = self
+        if accepted_count == 1 {
+            if let Some(result_tx) = self.pending_submits.remove(&last_sequence_number) {
+                let _ = result_tx.send(Ok(()));
+            } else {
+                warn!(
+                    "SubmitSharesSuccess for unknown pending sequence {}",
+                    last_sequence_number
+                );
+            }
+            return;
+        }
+
+        let mut acknowledged_sequences: Vec<u32> = self
             .pending_submits
             .range(..=last_sequence_number)
             .map(|(sequence_number, _)| *sequence_number)
-            .take(accepted_count as usize)
             .collect();
+
+        acknowledged_sequences.reverse();
+        acknowledged_sequences.truncate(accepted_count as usize);
+        acknowledged_sequences.reverse();
 
         if acknowledged_sequences.len() < accepted_count as usize {
             warn!(
@@ -967,6 +982,40 @@ mod tests {
             .unwrap();
 
         assert_eq!(result_rx.await.unwrap(), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn submit_success_resolves_exact_sequence_when_earlier_pending_exists() {
+        let upstream = test_upstream().await;
+        let (first_result_tx, first_result_rx) = oneshot::channel();
+        let (second_result_tx, second_result_rx) = oneshot::channel();
+
+        let (first_sequence, second_sequence) = upstream
+            .safe_lock(|u| {
+                (
+                    u.register_pending_submit(first_result_tx),
+                    u.register_pending_submit(second_result_tx),
+                )
+            })
+            .unwrap();
+
+        upstream
+            .safe_lock(|u| u.resolve_submit_success(second_sequence, 1))
+            .unwrap();
+
+        assert_eq!(second_result_rx.await.unwrap(), Ok(()));
+        assert!(
+            timeout(Duration::from_millis(50), first_result_rx)
+                .await
+                .is_err(),
+            "success for second sequence must not resolve first sequence"
+        );
+
+        upstream
+            .safe_lock(|u| {
+                u.resolve_submit_error(first_sequence, Err(RejectionReason::UpstreamRejected))
+            })
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Record worker monitor shares when the proxy locally accepts a downstream submit, before replying true to the miner, instead of waiting for upstream relay results. This keeps live worker hashrate tied to the real downstream mining flow while preserving separate upstream accounting for shares that are actually forwarded or acknowledged upstream.