### PR TITLE
FIX JD miner tag accounting to avoid invalid coinbase data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ tracing-appender = "0.2.4"
 #codec_sv2 = {features = ["noise_sv2","with_buffer_pool"], path = "../stratum/protocols/v2/codec-sv2" }
 #sv1_api = {path = "../stratum/protocols/v1" }
 
-demand-share-accounting-ext = { git = "https://github.com/demand-open-source/share-accounting-ext"}
-demand-sv2-connection = {git = "https://github.com/demand-open-source/demand-sv2-connection"}
-roles_logic_sv2 = { git = "https://github.com/demand-open-source/stratum", subdirectory = "protocols/v2/roles-logic-sv2"}
-framing_sv2 = { git = "https://github.com/demand-open-source/stratum", subdirectory = "protocols/v2/framing_sv2" }
-binary_sv2 = { git = "https://github.com/demand-open-source/stratum",subdirectory = "protocols/v2/binary_sv2"}
-noise_sv2 = { git = "https://github.com/demand-open-source/stratum",subdirectory = "protocols/v2/noise-sv2"}
-codec_sv2 = { git = "https://github.com/demand-open-source/stratum",subdirectory = "protocols/v2/codec-sv2", features = ["noise_sv2","with_buffer_pool"]}
-sv1_api = { git = "https://github.com/demand-open-source/stratum",subdirectory = "protocols/v1"}
+demand-share-accounting-ext = { git = "https://github.com/demand-open-source/share-accounting-ext" }
+demand-sv2-connection = { git = "https://github.com/demand-open-source/demand-sv2-connection" }
+roles_logic_sv2 = { git = "https://github.com/demand-open-source/stratum" }
+framing_sv2 = { git = "https://github.com/demand-open-source/stratum" }
+binary_sv2 = { git = "https://github.com/demand-open-source/stratum" }
+noise_sv2 = { git = "https://github.com/demand-open-source/stratum" }
+codec_sv2 = { git = "https://github.com/demand-open-source/stratum", features = ["noise_sv2", "with_buffer_pool"] }
+sv1_api = { git = "https://github.com/demand-open-source/stratum" }
 
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,8 +74,6 @@ struct Args {
     #[clap(long, short = 'u')]
     auto_update: bool,
     #[clap(long)]
-    signature: Option<String>,
-    #[clap(long)]
     miner_name: Option<String>,
     #[clap(long)]
     rpc_url: Option<String>,
@@ -187,7 +185,6 @@ pub struct Configuration {
     api_server_port: String,
     monitor: bool,
     auto_update: bool,
-    signature: String,
     miner_name: Option<String>,
     prioritizing_txs_config: Option<BitcoindRpcConfig>,
     missing_prioritizing_txs_variables: Vec<&'static str>,
@@ -249,7 +246,6 @@ and make that test pass."
         api_server_port: String,
         monitor: bool,
         auto_update: bool,
-        signature: String,
         miner_name: Option<String>,
         rpc_url: String,
         rpc_user: String,
@@ -296,7 +292,6 @@ and make that test pass."
             api_server_port,
             monitor,
             auto_update,
-            signature,
             miner_name,
             prioritizing_txs_config,
             missing_prioritizing_txs_variables,
@@ -382,7 +377,6 @@ and make that test pass."
             "3001".to_string(),
             false,
             false,
-            "DDxDD".to_string(),
             None,
             "http://127.0.0.1:8332".to_string(),
             "user".to_string(),
@@ -566,10 +560,6 @@ and make that test pass."
         Self::cfg().auto_update
     }
 
-    pub fn signature() -> String {
-        Self::cfg().signature.clone()
-    }
-
     pub fn miner_name() -> Option<String> {
         Self::cfg().miner_name.clone()
     }
@@ -623,22 +613,6 @@ and make that test pass."
             .or(config.token)
             .or_else(|| std::env::var("TOKEN").ok());
         println!("User token configured: {}", token.is_some());
-
-        let signature = match args.signature {
-            Some(s) => {
-                if s.len() == 2 {
-                    println!("Signature provided: DDx{s}");
-                    format!("DDx{s}")
-                } else {
-                    println!("Invalid signature provided, using DDxDD");
-                    "DDxDD".to_string()
-                }
-            }
-            None => {
-                println!("Signature not provided, using DDxDD");
-                "DDxDD".to_string()
-            }
-        };
 
         let tp_address = args
             .tp_address
@@ -894,7 +868,6 @@ and make that test pass."
             api_server_port,
             monitor,
             auto_update,
-            signature,
             miner_name,
             rpc_url,
             rpc_user,

--- a/src/jd_client/mining_downstream/mod.rs
+++ b/src/jd_client/mining_downstream/mod.rs
@@ -533,7 +533,7 @@ impl
                 "SOLO".as_bytes().to_vec(),
             )
             .inspect_err(|_| {
-                error!("Signature + extranonce lens exceed 32 bytes");
+                error!("Coinbase tag + extranonce lens exceed 32 bytes");
             })?;
 
             self.status.set_channel(channel_factory);

--- a/src/jd_client/mining_upstream/upstream.rs
+++ b/src/jd_client/mining_upstream/upstream.rs
@@ -412,7 +412,7 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
             vec![],
         )
         .inspect_err(|_| {
-            error!("Signature + extranonce lens exceed 32 bytes");
+            error!("Channel extranonce ranges exceed 32 bytes");
         })?;
         let extranonce: Extranonce = m
             .extranonce_prefix

--- a/src/jd_client/template_receiver/mod.rs
+++ b/src/jd_client/template_receiver/mod.rs
@@ -185,7 +185,10 @@ impl TemplateRx {
             Some(AllocateMiningJobTokenSuccess {
                 request_id: 0,
                 mining_job_token: vec![0; 32].try_into().expect("Internal error: this operation can not fail because the vec![0; 32] can always be converted into Inner"),
-                coinbase_output_max_additional_size: 100,
+                coinbase_output_max_additional_size: miner_coinbase_output
+                    .len()
+                    .try_into()
+                    .expect("miner coinbase output size should fit in u32"),
                 coinbase_output: miner_coinbase_output.to_vec().try_into().expect("Internal error: this operation can not fail because the Vec can always be converted into Inner"),
                 async_mining_allowed: true,
             })
@@ -208,6 +211,7 @@ impl TemplateRx {
         let miner_coinbase_output = self_mutex
             .safe_lock(|s| s.miner_coinbase_output.clone())
             .map_err(|_| Error::TemplateRxMutexCorrupted)?;
+        let miner_name = crate::config::Configuration::miner_name();
         let main_task = {
             let self_mutex = self_mutex.clone();
             //? check
@@ -311,15 +315,14 @@ impl TemplateRx {
                                         pending_new_template = Some(m);
                                         continue;
                                     }
-                                    if let Some(miner_name) =
-                                        crate::config::Configuration::miner_name()
-                                    {
-                                        assert!(miner_name.len() < 75);
-                                        crate::shared::miner_tag::tag_new_template(
-                                            &mut m,
-                                            miner_name.as_str(),
-                                        );
-                                    };
+                                    if let Err(e) = crate::shared::miner_tag::tag_new_template(
+                                        &mut m,
+                                        miner_name.as_deref(),
+                                    ) {
+                                        error!("Invalid miner tag coinbase script data: {e}");
+                                        ProxyState::update_tp_state(TpState::Down);
+                                        break;
+                                    }
                                     let new_phash = super::IS_NEW_PHASH_ARRIVED
                                         .load(std::sync::atomic::Ordering::Acquire);
                                     let last_is_future = match self_mutex
@@ -747,7 +750,8 @@ mod tests {
     ) {
         let frame = recv_std_frame(&mut from_client).await;
         with_decoded_message(frame, |message| match message {
-            PoolMessages::TemplateDistribution(TemplateDistribution::CoinbaseOutputDataSize(_)) => {
+            PoolMessages::TemplateDistribution(TemplateDistribution::CoinbaseOutputDataSize(m)) => {
+                assert_eq!(m.coinbase_output_max_additional_size, 1);
             }
             other => panic!("unexpected coinbase size message: {other:?}"),
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,13 +183,7 @@ async fn start_internal() {
     let mut router = router::Router::new(pool_addresses, auth_pub_k, None, None);
     let epsilon = Duration::from_millis(30_000);
     let best_upstream = router.select_pool_connect().await;
-    initialize_proxy(
-        &mut router,
-        best_upstream,
-        epsilon,
-        Configuration::signature(),
-    )
-    .await;
+    initialize_proxy(&mut router, best_upstream, epsilon).await;
     info!("exiting");
     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 }
@@ -198,7 +192,6 @@ async fn initialize_proxy(
     router: &mut Router,
     mut pool_addr: Option<std::net::SocketAddr>,
     epsilon: Duration,
-    signature: String,
 ) {
     let shutdown_signal = shutdown::handle_shutdown();
     loop {
@@ -231,23 +224,17 @@ async fn initialize_proxy(
         let sv1_ingress_abortable = ingress::sv1_ingress::start_listen_for_downstream(downs_sv1_tx);
 
         let (translator_up_tx, mut translator_up_rx) = channel(10);
-        let translator_abortable = match translator::start(
-            downs_sv1_rx,
-            translator_up_tx,
-            stats_sender.clone(),
-            signature.clone(),
-        )
-        .await
-        {
-            Ok(abortable) => abortable,
-            Err(e) => {
-                error!("Impossible to initialize translator: {e}");
-                // Impossible to start the proxy so we restart proxy
-                ProxyState::update_translator_state(TranslatorState::Down);
-                ProxyState::update_tp_state(TpState::Down);
-                return;
-            }
-        };
+        let translator_abortable =
+            match translator::start(downs_sv1_rx, translator_up_tx, stats_sender.clone()).await {
+                Ok(abortable) => abortable,
+                Err(e) => {
+                    error!("Impossible to initialize translator: {e}");
+                    // Impossible to start the proxy so we restart proxy
+                    ProxyState::update_translator_state(TranslatorState::Down);
+                    ProxyState::update_tp_state(TpState::Down);
+                    return;
+                }
+            };
 
         let (from_jdc_to_share_accounter_send, from_jdc_to_share_accounter_recv) = channel(10);
         let (from_share_accounter_to_jdc_send, from_share_accounter_to_jdc_recv) = channel(10);

--- a/src/shared/miner_tag.rs
+++ b/src/shared/miner_tag.rs
@@ -5,6 +5,9 @@ use roles_logic_sv2::template_distribution_sv2::NewTemplate;
 
 // DO NOT CHANGE IT WTHOUT TESTING CAN BREACK EVERYTHING
 pub const MAX_MINER_NAME_LEN: usize = 10;
+const MAX_COINBASE_SCRIPT_LEN: usize = 100;
+const MAX_EXTRANONCE_LEN: usize = 32;
+const MAX_DIRECT_PUSH_LEN: usize = 75;
 
 const TAG_PREFIX: &str = "/DMND/";
 const TAG_SUFFIX: &str = "/";
@@ -24,16 +27,46 @@ pub fn format_miner_tag(miner_name: Option<&str>) -> String {
     format!("{TAG_PREFIX}{}{TAG_SUFFIX}", miner_name.unwrap_or_default())
 }
 
-pub fn append_tag_to_script_prefix<'a>(coinbase_prefix: B0255<'a>, tag: &[u8]) -> B0255<'a> {
+pub fn append_tag_to_script_prefix<'a>(
+    coinbase_prefix: B0255<'a>,
+    tag: &[u8],
+) -> Result<B0255<'a>, String> {
+    if tag.len() > MAX_DIRECT_PUSH_LEN {
+        return Err(format!(
+            "coinbase script tag must fit in a direct push, got {} bytes",
+            tag.len()
+        ));
+    }
+
+    let tagged_prefix_len = coinbase_prefix.len() + tag.len() + 1;
+    let max_prefix_len = MAX_COINBASE_SCRIPT_LEN - MAX_EXTRANONCE_LEN;
+    if tagged_prefix_len > max_prefix_len {
+        return Err(format!(
+            "coinbase script prefix too long after miner tag: \
+             prefix_len={} tag_push_len={} max_prefix_len={} max_script_len={} max_extranonce_len={}",
+            coinbase_prefix.len(),
+            tag.len() + 1,
+            max_prefix_len,
+            MAX_COINBASE_SCRIPT_LEN,
+            MAX_EXTRANONCE_LEN
+        ));
+    }
+
     let mut prefix = coinbase_prefix.to_vec();
     prefix.push(tag.len() as u8);
     prefix.extend_from_slice(tag);
-    prefix.try_into().expect("tag len is checked before")
+    prefix
+        .try_into()
+        .map_err(|_| "tagged coinbase prefix does not fit in B0255".to_string())
 }
 
-pub fn tag_new_template<'a>(template: &mut NewTemplate<'a>, miner_name: &str) {
-    let tag = format_miner_tag(Some(miner_name)).into_bytes();
-    template.coinbase_prefix = append_tag_to_script_prefix(template.coinbase_prefix.clone(), &tag);
+pub fn tag_new_template<'a>(
+    template: &mut NewTemplate<'a>,
+    miner_name: Option<&str>,
+) -> Result<(), String> {
+    let tag = format_miner_tag(miner_name).into_bytes();
+    template.coinbase_prefix = append_tag_to_script_prefix(template.coinbase_prefix.clone(), &tag)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -47,7 +80,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_names_longer_than_thirty_bytes() {
+    fn rejects_names_longer_than_max_len() {
         let too_long = "a".repeat(MAX_MINER_NAME_LEN + 1);
         assert!(validate_miner_name(&too_long).is_err());
     }
@@ -58,9 +91,36 @@ mod tests {
             .try_into()
             .expect("sample script prefix should fit in B0255");
         let tag = b"/DMND//";
-        let tagged = append_tag_to_script_prefix(prefix, tag).to_vec();
+        let tagged = append_tag_to_script_prefix(prefix, tag)
+            .expect("tagged script prefix should fit")
+            .to_vec();
 
         assert_eq!(tagged, b"\x03\x5a\x59\x0e\x00\x07/DMND//".to_vec());
+    }
+
+    #[test]
+    fn rejects_tag_that_does_not_fit_coinbase_script_budget() {
+        let prefix: B0255<'static> = vec![0_u8; MAX_COINBASE_SCRIPT_LEN - MAX_EXTRANONCE_LEN]
+            .try_into()
+            .expect("sample script prefix should fit in B0255");
+
+        let err = append_tag_to_script_prefix(prefix, b"/DMND//")
+            .expect_err("tagged script prefix should exceed the budget");
+
+        assert!(err.contains("coinbase script prefix too long"));
+    }
+
+    #[test]
+    fn rejects_tag_that_needs_pushdata_encoding() {
+        let prefix: B0255<'static> = vec![0_u8; 1]
+            .try_into()
+            .expect("sample script prefix should fit in B0255");
+        let tag = vec![0_u8; MAX_DIRECT_PUSH_LEN + 1];
+
+        let err = append_tag_to_script_prefix(prefix, &tag)
+            .expect_err("oversized tag should be rejected");
+
+        assert!(err.contains("direct push"));
     }
 
     #[test]
@@ -86,7 +146,7 @@ mod tests {
             merkle_path,
         };
 
-        tag_new_template(&mut template, "miner4");
+        tag_new_template(&mut template, Some("miner4")).expect("tagged template should fit");
         assert_eq!(
             template.coinbase_prefix.to_vec(),
             b"\x03\x5a\x59\x0e\x00\x0d/DMND/miner4/".to_vec()

--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -434,7 +434,8 @@ impl Downstream {
         // `handle_message` in `IsServer` trait + calls `handle_request`
         // TODO: Map err from V1Error to Error::V1Error
 
-        let response = self_.safe_lock(|s| s.handle_message(message_sv1.clone()))?;
+        let response =
+            self_.safe_lock(|s| s.handle_message(message_sv1.clone()).map_err(Box::new))?;
         match response {
             Ok(res) => {
                 if let Some(r) = res {
@@ -460,12 +461,12 @@ impl Downstream {
                 }
             }
             Err(e) => {
-                if matches!(e, sv1_api::error::Error::InvalidSubmission) {
+                if matches!(e.as_ref(), sv1_api::error::Error::InvalidSubmission) {
                     Self::reject_invalid_submit(self_, &message_sv1).await?;
                     return Ok(());
                 }
                 error!("{e}");
-                Err(Error::V1Protocol(Box::new(e)))
+                Err(Error::V1Protocol(e))
             }
         }
     }

--- a/src/translator/mod.rs
+++ b/src/translator/mod.rs
@@ -1,4 +1,4 @@
-mod downstream;
+pub(crate) mod downstream;
 
 mod error;
 mod proxy;

--- a/src/translator/mod.rs
+++ b/src/translator/mod.rs
@@ -35,7 +35,6 @@ pub async fn start(
         Option<Address>,
     )>,
     stats_sender: crate::api::stats::StatsSender,
-    signature: String,
 ) -> Result<AbortOnDrop, Error<'static>> {
     let task_manager = TaskManager::initialize(pool_connection.clone());
     let abortable = task_manager
@@ -104,7 +103,6 @@ pub async fn start(
         target.clone(),
         diff_config.clone(),
         send_to_up,
-        signature,
     )
     .await?;
 

--- a/src/translator/task_manager.rs
+++ b/src/translator/task_manager.rs
@@ -25,13 +25,13 @@ pub struct TaskManager {
 }
 
 impl TaskManager {
-    #[allow(unused_variables)]
     pub fn initialize(
-        // We need this to be alive for all the live of the translator
+        // Keep this alive for the translator lifetime.
         up_connection: Sender<(Sender<Message>, Receiver<Message>, Option<Address>)>,
     ) -> Arc<Mutex<Self>> {
         let (sender, mut receiver) = mpsc::channel(10);
         let handle = tokio::task::spawn(async move {
+            let _up_connection = up_connection;
             let mut tasks = vec![];
             while let Some(task) = receiver.recv().await {
                 tasks.push(task);
@@ -40,8 +40,6 @@ impl TaskManager {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(1000)).await;
             }
-            #[allow(unreachable_code)]
-            drop(up_connection)
         });
         Arc::new(Mutex::new(Self {
             send_task: sender,

--- a/src/translator/upstream/upstream.rs
+++ b/src/translator/upstream/upstream.rs
@@ -90,7 +90,6 @@ pub struct Upstream {
     // than the configured percentage
     pub(super) difficulty_config: Arc<Mutex<UpstreamDifficultyConfig>>,
     pub sender: TSender<Mining<'static>>,
-    signature: String,
     sent_up: u32,
     rejected: u32,
     toa: Vec<std::time::Instant>,
@@ -119,7 +118,6 @@ impl Upstream {
         target: Arc<Mutex<Vec<u8>>>,
         difficulty_config: Arc<Mutex<UpstreamDifficultyConfig>>,
         sender: TSender<Mining<'static>>,
-        signature: String,
     ) -> ProxyResult<'static, Arc<Mutex<Self>>> {
         Ok(Arc::new(Mutex::new(Self {
             extranonce_prefix: None,
@@ -134,7 +132,6 @@ impl Upstream {
             target,
             difficulty_config,
             sender,
-            signature,
             sent_up: 0,
             rejected: 0,
             toa: Vec::new(),
@@ -534,11 +531,9 @@ impl Upstream {
                         }
                     };
 
-                    let (channel_id, signature) = match self_.safe_lock(|s| {
-                        s.channel_id
-                            .ok_or(RolesLogicError::NotFoundChannelId)
-                            .map(|channel_id| (channel_id, s.signature.clone()))
-                    }) {
+                    let channel_id = match self_
+                        .safe_lock(|s| s.channel_id.ok_or(RolesLogicError::NotFoundChannelId))
+                    {
                         Ok(Ok(values)) => values,
                         Ok(Err(e)) => {
                             error!("{}", Error::RolesSv2Logic(e));
@@ -578,9 +573,6 @@ impl Upstream {
 
                     share.channel_id = channel_id;
                     share.sequence_number = sequence_number;
-                    let mut extranonce = signature.as_bytes().to_vec();
-                    extranonce.extend_from_slice(&share.extranonce.to_vec());
-                    share.extranonce = extranonce.try_into().unwrap();
 
                     let message = roles_logic_sv2::parsers::Mining::SubmitSharesExtended(share);
 
@@ -721,16 +713,12 @@ impl ParseUpstreamMiningMessages<Downstream, NullDownstreamMiningSelector, NoRou
     /// role in a SV1 `mining.subscribe` message response.
     fn handle_open_extended_mining_channel_success(
         &mut self,
-        mut m: roles_logic_sv2::mining_sv2::OpenExtendedMiningChannelSuccess,
+        m: roles_logic_sv2::mining_sv2::OpenExtendedMiningChannelSuccess,
     ) -> Result<SendTo<Downstream>, RolesLogicError> {
         info!(
             "Handling OpenExtendedMiningChannelSuccess message from Pool for Channel Id: {}",
             m.channel_id
         );
-        let mut prefix = m.extranonce_prefix.to_vec();
-        prefix.extend_from_slice(self.signature.as_bytes());
-        m.extranonce_prefix = prefix.try_into().unwrap();
-        m.extranonce_size -= self.signature.len() as u16;
         let tproxy_e1_len =
             proxy_extranonce1_len(m.extranonce_size as usize, self.min_extranonce_size.into())
                 as u16;
@@ -961,7 +949,6 @@ mod tests {
                 UpstreamDifficultyConfig::new(crate::CHANNEL_DIFF_UPDTATE_INTERVAL, 0.0).0,
             )),
             sender,
-            "sig".to_string(),
         )
         .await
         .unwrap()
@@ -1084,7 +1071,6 @@ mod tests {
             Arc::new(Mutex::new(vec![0; 32])),
             difficulty_config.clone(),
             sender,
-            "sig".to_string(),
         )
         .await
         .unwrap();

--- a/tests/library_init.rs
+++ b/tests/library_init.rs
@@ -146,7 +146,6 @@ async fn library_init_sv2_setup_connection() {
         "3001".to_string(),
         false,
         false,
-        "DDxDD".to_string(),
         None,
         "http://127.0.0.1:8332".to_string(),
         "user".to_string(),

--- a/tests/library_init.rs
+++ b/tests/library_init.rs
@@ -17,18 +17,7 @@ use stratum_apps::stratum_core::common_messages_sv2::{
     Protocol, MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
 };
 
-fn ensure_port_free_or_skip(address: &str) -> bool {
-    match TcpListener::bind(address) {
-        Ok(_) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-            eprintln!("skipping: {address} is in use");
-            false
-        }
-        Err(e) => panic!("failed to probe {address}: {e}"),
-    }
-}
-
-async fn wait_for_port_to_be_bound(address: &str) {
+async fn wait_for_port_to_be_bound(address: SocketAddr) {
     let started = std::time::Instant::now();
     loop {
         match TcpListener::bind(address) {
@@ -47,20 +36,12 @@ async fn wait_for_port_to_be_bound(address: &str) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn library_init_sv2_setup_connection() {
-    if !ensure_port_free_or_skip("127.0.0.1:20000") {
-        return;
-    }
-    if !ensure_port_free_or_skip("127.0.0.1:20001") {
-        return;
-    }
-    if !ensure_port_free_or_skip("127.0.0.1:20002") {
-        return;
-    }
-
-    let proxy_target: SocketAddr = "127.0.0.1:20000".parse().unwrap();
-    let mock_pool_mining_addr: SocketAddr = "127.0.0.1:20001".parse().unwrap();
-    let mock_pool_jd_addr: SocketAddr = "127.0.0.1:20002".parse().unwrap();
+    let proxy_target = get_available_address();
+    let mock_pool_mining_addr = get_available_address();
+    let mock_pool_jd_addr = get_available_address();
     let tp_sniffer_addr = get_available_address();
+    let sv1_listen_addr = get_available_address();
+    let api_server_port = get_available_address().port().to_string();
     let (template_provider, template_provider_addr) =
         start_template_provider(Some(1), DifficultyLevel::Low);
 
@@ -87,7 +68,7 @@ async fn library_init_sv2_setup_connection() {
         Some(30),
     );
     pool_sniffer.start();
-    wait_for_port_to_be_bound("127.0.0.1:20000").await;
+    wait_for_port_to_be_bound(proxy_target).await;
 
     let jd_pool_sniffer = Sniffer::new(
         "proxy-pool-jd",
@@ -101,7 +82,7 @@ async fn library_init_sv2_setup_connection() {
         let jd_pool_sniffer = jd_pool_sniffer.clone();
         tokio::spawn(async move {
             loop {
-                if let Ok(listener) = TcpListener::bind("127.0.0.1:20000") {
+                if let Ok(listener) = TcpListener::bind(proxy_target) {
                     drop(listener);
                     jd_pool_sniffer.start();
                     break;
@@ -125,10 +106,11 @@ async fn library_init_sv2_setup_connection() {
         Some("test_token".to_string()),
         Some(tp_sniffer_addr.to_string()),
         None,
-        vec![mock_pool_mining_addr.to_string()],
+        vec![proxy_target.to_string()],
         120_000,
         0,
         100_000_000_000_000.0,
+        131_072.0,
         "info".to_string(),
         "off".to_string(),
         false,
@@ -137,13 +119,13 @@ async fn library_init_sv2_setup_connection() {
         false,
         false,
         true,
-        None,
+        Some(sv1_listen_addr.to_string()),
         None,
         250,
         16_384,
         None,
         250,
-        "3001".to_string(),
+        api_server_port,
         false,
         false,
         None,


### PR DESCRIPTION
Remove the translator proxy signature from extranonce handling and keep the JD miner tag in coinbase script data only. CoinbaseOutputDataSize now reports only serialized output bytes, while tag insertion validates direct-push encoding and the 100-byte coinbase script budget before mutating templates.