### PR TITLE
cherry-pick: JD debug logging from #162 (fixes #167)

### DIFF
--- a/src/jd_client/job_declarator/message_handler.rs
+++ b/src/jd_client/job_declarator/message_handler.rs
@@ -1,4 +1,4 @@
-use super::JobDeclarator;
+use super::{ErrorDetails, JobDeclarator};
 use roles_logic_sv2::{
     handlers::{job_declaration::ParseServerJobDeclarationMessages, SendTo_},
     job_declaration_sv2::{
@@ -9,7 +9,7 @@ use roles_logic_sv2::{
 };
 pub type SendTo = SendTo_<JobDeclaration<'static>, ()>;
 use roles_logic_sv2::errors::Error;
-use tracing::debug;
+use tracing::{debug, error};
 
 impl ParseServerJobDeclarationMessages for JobDeclarator {
     fn handle_allocate_mining_job_token_success(
@@ -31,8 +31,16 @@ impl ParseServerJobDeclarationMessages for JobDeclarator {
 
     fn handle_declare_mining_job_error(
         &mut self,
-        _message: DeclareMiningJobError,
+        message: DeclareMiningJobError,
     ) -> Result<SendTo, Error> {
+        let error_code = ErrorDetails::borrowed(message.error_code.inner_as_ref());
+        let error_details = ErrorDetails::borrowed(message.error_details.inner_as_ref());
+        error!(
+            request_id = message.request_id,
+            error_code = %error_code,
+            error_details = %error_details,
+            "DeclareMiningJobError received"
+        );
         // TODO consider using declarative names instead of setting states
         super::super::IS_CUSTOM_JOB_SET.store(true, std::sync::atomic::Ordering::Release);
         Ok(SendTo::None(None))

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -13,8 +13,10 @@ use roles_logic_sv2::{
     utils::Mutex,
 };
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     convert::TryInto,
+    fmt,
 };
 use task_manager::TaskManager;
 use tokio::sync::mpsc::{Receiver as TReceiver, Sender as TSender};
@@ -423,7 +425,14 @@ impl JobDeclarator {
                         }
                     }
                     Ok(SendTo::None(Some(JobDeclaration::DeclareMiningJobError(m)))) => {
-                        error!("Job is not verified: {:?}", m);
+                        let error_code = ErrorDetails::owned(m.error_code.to_vec());
+                        let error_details = ErrorDetails::borrowed(m.error_details.inner_as_ref());
+                        error!(
+                            request_id = m.request_id,
+                            error_code = %error_code,
+                            error_details = %error_details,
+                            "Job is not verified"
+                        );
                     }
                     Ok(SendTo::None(None)) => (),
                     Ok(SendTo::Respond(m)) => {
@@ -648,6 +657,33 @@ async fn check_missing_prioritized_txids(missing_txids: Vec<Txid>, template_id: 
                     error = %e,
                     "failed to check prioritized transaction mempool state"
                 );
+            }
+        }
+    }
+}
+
+struct ErrorDetails<'a>(Cow<'a, [u8]>);
+
+impl<'a> ErrorDetails<'a> {
+    fn borrowed(bytes: &'a [u8]) -> Self {
+        Self(Cow::Borrowed(bytes))
+    }
+
+    fn owned(bytes: Vec<u8>) -> Self {
+        Self(Cow::Owned(bytes))
+    }
+}
+
+impl<'a> fmt::Display for ErrorDetails<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match std::str::from_utf8(self.0.as_ref()) {
+            Ok(text) => f.write_str(text),
+            Err(_) => {
+                f.write_str("0x")?;
+                for byte in self.0.as_ref() {
+                    write!(f, "{:02x}", byte)?;
+                }
+                Ok(())
             }
         }
     }

--- a/src/jd_client/job_declarator/mod.rs
+++ b/src/jd_client/job_declarator/mod.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use task_manager::TaskManager;
 use tokio::sync::mpsc::{Receiver as TReceiver, Sender as TSender};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use async_recursion::async_recursion;
 use nohash_hasher::BuildNoHashHasher;
@@ -246,10 +246,11 @@ impl JobDeclarator {
             .map_err(|_| Error::JobDeclaratorMutexCorrupted)?;
 
         let template_transactions = tx_list_.to_vec();
+        let tx_count = template_transactions.len();
         let prioritized_txids = crate::prioritized_transactions::snapshot_txids();
         let mut template_txids = HashSet::with_capacity(template_transactions.len());
-        let mut tx_list: Vec<Transaction> = Vec::new();
-        let mut tx_ids = vec![];
+        let mut tx_list: Vec<Transaction> = Vec::with_capacity(tx_count);
+        let mut tx_ids = Vec::with_capacity(tx_count);
         for tx in template_transactions {
             let transaction: Result<Transaction, bitcoin::consensus::encode::Error> =
                 bitcoin::consensus::deserialize(&tx);
@@ -266,6 +267,11 @@ impl JobDeclarator {
                 }
             }
         }
+        debug!(
+            template_id = template.template_id,
+            tx_count,
+            "Received template transaction list"
+        );
         let missing_txids = missing_prioritized_txids(&prioritized_txids, &template_txids);
         if !missing_txids.is_empty() {
             tokio::task::spawn(check_missing_prioritized_txids(


### PR DESCRIPTION
## Summary

Cherry-picks the three logging commits from closed #162 as requested in #167.

## Commits included

- `e853948` — Log ProvideMissingTransactions responses
- `221592b` — Log template transaction counts
- `3a8346f` — Decode "Job is not verified" reason into readable logs

## Commits excluded (per @jbesraa feedback on #162)

- `7916d6c` — position validation loop (latency concern)
- `0ce6d5a` — requested txid logging (feature flag concern)

## What this does

- Adds `debug!` when sending ProvideMissingTransactionsSuccess (request_id + tx count)
- Adds `debug!` when receiving template transaction lists (template_id + tx_count)
- Decodes DeclareMiningJobError fields as UTF-8 or hex via `ErrorDetails` helper
- Structured `error!` logging for "Job is not verified" and DeclareMiningJobError

## What this does NOT do

- Does not fix the underlying intermittent JD template bug
- Does not add validation loops or extra latency to the missing-tx flow

## Conflict notes

`221592b` and `3a8346f` were manually merged against current master (prioritized-tx logic in `on_new_template` was preserved).

## Test plan

- [x] `cargo build` — passed
- [x] `cargo test` — 86 passed, 0 failed (79 lib + 6 integration + 1 library_init)

Screenshots attached.
<img width="1690" height="356" alt="image" src="https://github.com/user-attachments/assets/8c68d088-d71f-4e65-a8ac-0db4f13088f0" />

Fixes #167
Cherry-picked from #162