### PR TITLE
fix(api): report admission saturation in /api/health without marking the proxy dead

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,7 +18,16 @@ pub struct AppState {
     router: Router,
     stats_sender: StatsSender,
     downstream_handoff: crate::DownstreamHandoffSender,
+    downstream_connection_slots: Option<Arc<tokio::sync::Semaphore>>,
     prioritizing_txs: Option<PrioritizingTxs>,
+}
+
+impl AppState {
+    pub(crate) fn is_admission_saturated(&self) -> bool {
+        self.downstream_connection_slots
+            .as_ref()
+            .is_some_and(|s| s.available_permits() == 0)
+    }
 }
 
 #[derive(Clone)]
@@ -31,6 +40,7 @@ pub(crate) async fn start(
     router: Router,
     stats_sender: StatsSender,
     downstream_handoff: crate::DownstreamHandoffSender,
+    downstream_connection_slots: Option<Arc<tokio::sync::Semaphore>>,
 ) {
     let prioritizing_txs = Configuration::bitcoind_rpc_config().map(|config| {
         let rpc = Arc::new(BitcoindRpc::new(
@@ -49,6 +59,7 @@ pub(crate) async fn start(
         router,
         stats_sender,
         downstream_handoff,
+        downstream_connection_slots,
         prioritizing_txs,
     };
     let app = AxumRouter::new()

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1,5 +1,4 @@
 use super::{utils::get_cpu_and_memory_usage, AppState};
-use crate::config::Configuration;
 use crate::proxy_state::ProxyState;
 use axum::{
     extract::{Path, State},
@@ -109,49 +108,47 @@ impl Api {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(APIResponse::error(Some(
-                    "Overloaded: translator handoff channel is closed".to_string(),
+                    "Proxy down: translator handoff channel is closed".to_string(),
                 ))),
             );
         }
 
-        if state.downstream_handoff.capacity() == 0 {
-            let max_capacity = state.downstream_handoff.max_capacity();
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(APIResponse::error(Some(format!(
-                    "Overloaded: translator handoff channel queue is full (0/{max_capacity} slots available)"
-                )))),
-            );
-        }
-
-        if let Some(max_active_downstreams) = Configuration::max_active_downstreams() {
-            if let Ok(stats) = state.stats_sender.collect_stats().await {
-                let active_downstreams = stats.len();
-                if active_downstreams >= max_active_downstreams {
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Json(APIResponse::error(Some(format!(
-                            "Overloaded: active downstreams {active_downstreams}/{max_active_downstreams}"
-                        )))),
-                    );
-                }
-            }
-        }
-
         match ProxyState::is_proxy_down() {
-            (false, None) => (
-                StatusCode::OK,
-                Json(APIResponse::success(Some("Proxy OK".to_string()))),
-            ),
-            (true, Some(states)) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(APIResponse::error(Some(states))),
-            ),
-            _ => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(APIResponse::error(Some("Unknown proxy state".to_string()))),
-            ),
+            (true, Some(states)) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(APIResponse::error(Some(states))),
+                );
+            }
+            (true, None) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(APIResponse::error(Some("Unknown proxy state".to_string()))),
+                );
+            }
+            (false, None) => {}
+            (false, Some(_)) => unreachable!("is_proxy_down should not return Some when false"),
         }
+
+        let saturated = state.is_admission_saturated();
+        let handoff_backlog_full = state.downstream_handoff.capacity() == 0;
+        let body = json!({
+            "status": "ok",
+            "saturated": saturated,
+            "handoff_backlog_full": handoff_backlog_full,
+            "message": if saturated {
+                "Proxy is alive but admission saturated: not accepting new connections"
+            } else if handoff_backlog_full {
+                "Proxy is alive but translator handoff backlog is full"
+            } else {
+                "Proxy OK"
+            }
+        });
+
+        (
+            StatusCode::OK,
+            Json(APIResponse::success(Some(body))),
+        )
     }
 
     pub async fn send_tx_to_bitcoind(
@@ -313,6 +310,7 @@ impl<T: Serialize> APIResponse<T> {
 
 #[tokio::test]
 async fn health_check_reports_full_translator_handoff() {
+    use axum::body::to_bytes;
     use axum::extract::State;
     use axum::response::IntoResponse;
     use std::{net::IpAddr, time::Instant};
@@ -337,6 +335,7 @@ async fn health_check_reports_full_translator_handoff() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
+        downstream_connection_slots: None,
         prioritizing_txs: Some(super::PrioritizingTxs {
             rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
                 "http://127.0.0.1:8332".to_string(),
@@ -346,6 +345,69 @@ async fn health_check_reports_full_translator_handoff() {
             )),
             api_tx_token: "api-token".to_string(),
         }),
+    };
+
+    let response = Api::health_check(State(state)).await.into_response();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["saturated"], false);
+    assert_eq!(body["data"]["handoff_backlog_full"], true);
+}
+
+#[tokio::test]
+async fn health_check_returns_200_when_admission_saturated() {
+    use axum::body::to_bytes;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Semaphore};
+
+    let auth_pub_k = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
+    let router = crate::router::Router::new(vec![], auth_pub_k, None, None);
+
+    let (handoff_tx, _handoff_rx) = mpsc::channel(8);
+
+    let state = AppState {
+        router,
+        stats_sender: crate::api::stats::StatsSender::new(),
+        downstream_handoff: handoff_tx,
+        downstream_connection_slots: Some(Arc::new(Semaphore::new(0))),
+        prioritizing_txs: None,
+    };
+
+    let response = Api::health_check(State(state)).await.into_response();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["saturated"], true);
+    assert_eq!(body["data"]["handoff_backlog_full"], false);
+}
+
+#[tokio::test]
+async fn health_check_returns_503_when_handoff_channel_closed() {
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use tokio::sync::mpsc;
+
+    let auth_pub_k = crate::AUTH_PUB_KEY.parse().expect("Invalid public key");
+    let router = crate::router::Router::new(vec![], auth_pub_k, None, None);
+
+    let (handoff_tx, handoff_rx) = mpsc::channel(1);
+    drop(handoff_rx);
+
+    let state = AppState {
+        router,
+        stats_sender: crate::api::stats::StatsSender::new(),
+        downstream_handoff: handoff_tx,
+        downstream_connection_slots: None,
+        prioritizing_txs: None,
     };
 
     let response = Api::health_check(State(state)).await.into_response();
@@ -367,6 +429,7 @@ async fn send_tx_reports_unavailable_when_rpc_is_disabled() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
+        downstream_connection_slots: None,
         prioritizing_txs: None,
     };
 
@@ -395,6 +458,7 @@ async fn send_tx_rejects_missing_api_tx_token_header() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
+        downstream_connection_slots: None,
         prioritizing_txs: Some(super::PrioritizingTxs {
             rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
                 "http://127.0.0.1:8332".to_string(),
@@ -547,6 +611,7 @@ async fn get_prioritized_transactions_returns_snapshot() {
         router,
         stats_sender: crate::api::stats::StatsSender::new(),
         downstream_handoff: handoff_tx,
+        downstream_connection_slots: None,
         prioritizing_txs: Some(super::PrioritizingTxs {
             rpc: std::sync::Arc::new(crate::api::bitcoin_rpc::BitcoindRpc::new(
                 format!("http://{addr}"),

--- a/src/ingress/sv1_ingress.rs
+++ b/src/ingress/sv1_ingress.rs
@@ -66,14 +66,15 @@ impl AcceptWindowLimiter {
     }
 }
 
-pub fn start_listen_for_downstream(downstreams: Sender<DownstreamConnection>) -> AbortOnDrop {
+pub fn start_listen_for_downstream(
+    downstreams: Sender<DownstreamConnection>,
+    connection_slots: Option<Arc<Semaphore>>,
+) -> AbortOnDrop {
     tokio::task::spawn(async move {
         let down_addr: String = Configuration::downstream_listening_addr()
             .unwrap_or(crate::DEFAULT_LISTEN_ADDRESS.to_string());
         let downstream_addr: SocketAddr = down_addr.parse().expect("Invalid listen address");
         let max_active_downstreams = Configuration::max_active_downstreams();
-        let connection_slots =
-            max_active_downstreams.map(|max| Arc::new(Semaphore::new(max)));
         let accept_backoff = Duration::from_millis(Configuration::accept_backoff_ms());
         let accept_window = Duration::from_millis(Configuration::accept_window_ms());
         let max_accepts_per_window = Configuration::max_accepts_per_window();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,10 @@ use lazy_static::lazy_static;
 use proxy_state::{PoolState, ProxyState, TpState, TranslatorState};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    OnceLock,
+    Arc, OnceLock,
 };
 use std::{net::SocketAddr, time::Duration};
-use tokio::sync::mpsc::channel;
+use tokio::sync::{mpsc::channel, Semaphore};
 use tracing::{error, info, warn};
 
 mod api;
@@ -221,7 +221,12 @@ async fn initialize_proxy(
 
         let (downs_sv1_tx, downs_sv1_rx) = channel(crate::DOWNSTREAM_ACCEPT_BUFFER_SIZE);
         let downstream_handoff = downs_sv1_tx.clone();
-        let sv1_ingress_abortable = ingress::sv1_ingress::start_listen_for_downstream(downs_sv1_tx);
+        let connection_slots = Configuration::max_active_downstreams()
+            .map(|max| Arc::new(Semaphore::new(max)));
+        let sv1_ingress_abortable = ingress::sv1_ingress::start_listen_for_downstream(
+            downs_sv1_tx,
+            connection_slots.clone(),
+        );
 
         let (translator_up_tx, mut translator_up_rx) = channel(10);
         let translator_abortable =
@@ -307,8 +312,12 @@ async fn initialize_proxy(
         if let Some(jdc_handle) = jdc_abortable {
             abort_handles.push((jdc_handle, "jdc".to_string()));
         }
-        let server_handle =
-            tokio::spawn(api::start(router.clone(), stats_sender, downstream_handoff));
+        let server_handle = tokio::spawn(api::start(
+            router.clone(),
+            stats_sender,
+            downstream_handoff,
+            connection_slots,
+        ));
         abort_handles.push((server_handle.into(), "api_server".to_string()));
         match monitor(router, abort_handles, epsilon, shutdown_signal.clone()).await {
             Reconnect::NewUpstream(new_pool_addr) => {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -142,7 +142,7 @@ async fn basic() {
         Receiver<DownstreamConnection>,
     ) = tokio::sync::mpsc::channel(1);
 
-    let ingress = sv1_ingress::start_listen_for_downstream(downstreams_tx);
+    let ingress = sv1_ingress::start_listen_for_downstream(downstreams_tx, None);
 
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {


### PR DESCRIPTION
## Summary

Fixes #244

When the proxy hits its max active downstream limit, it’s still **healthy** — it’s just not accepting new miners. Before this change, `/api/health` could return **503** based on signals that don’t reflect real admission capacity (handoff queue depth or stats count). Load balancers and operators could treat a live, working proxy as dead and keep sending miners to it anyway.

This PR separates **liveness** (“is the proxy up?”) from **readiness** (“can it take more miners?”):

- **503** only when something is actually wrong: translator handoff channel is closed, or the proxy is globally down.
- **200** when the proxy is alive, with a JSON body that reports saturation clearly.

Saturation is read from the **ingress admission semaphore** — the same gate that stops new TCP accepts when the proxy is full — not from the handoff queue (which drains quickly into background setup) or from `stats.len()` (which can lag).

## What changed

| Before | After |
|--------|--------|
| Full handoff queue → 503 | 200 + `handoff_backlog_full: true` |
| `stats.len() >= max` → 503 | 200 + `saturated: true` (from semaphore) |
| Alive and healthy → 200 `"Proxy OK"` | 200 with structured body |

Example response when alive but at capacity:

```json
{
  "success": true,
  "data": {
    "status": "ok",
    "saturated": true,
    "handoff_backlog_full": false,
    "message": "Proxy is alive but admission saturated: not accepting new connections"
  }
}