### PR TITLE
fix(translator): eagerly mark_closed on malformed-JSON disconnect (#241)

### DIFF
--- a/src/translator/downstream/receive_from_downstream.rs
+++ b/src/translator/downstream/receive_from_downstream.rs
@@ -106,6 +106,12 @@ pub async fn start_receive_downstream(
                             sv1_api::error::Error::InvalidJsonRpcMessageKind
                         ))
                     );
+                    // Mark closed eagerly before breaking so deferred bootstrap tasks
+                    // that check is_closed() see the disconnect immediately, even if
+                    // the post-loop teardown hasn't run yet. (See #241)
+                    if let Err(e) = downstream.safe_lock(|d| d.mark_closed()) {
+                        error!("Failed to mark downstream {connection_id} closed: {e}");
+                    }
                     break;
                 }
             }
@@ -157,4 +163,244 @@ pub async fn start_receive_downstream(
     TaskManager::add_receive_downstream(task_manager, handle.into(), connection_id)
         .await
         .map_err(|_| Error::TranslatorTaskManagerFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        api::stats::StatsSender,
+        translator::{
+            downstream::{
+                downstream::{Downstream, DownstreamDifficultyConfig},
+                notify::start_notify,
+                task_manager::TaskManager,
+                DownstreamMessages,
+            },
+            upstream::diff_management::UpstreamDifficultyConfig,
+        },
+    };
+    use pid::Pid;
+    use roles_logic_sv2::utils::Mutex;
+    use std::{collections::VecDeque, sync::Arc, time::Duration};
+    use sv1_api::{
+        json_rpc::Message,
+        server_to_client::Notify,
+        utils::{HexU32Be, MerkleNode, PrevHash},
+    };
+    use tokio::sync::{broadcast, mpsc::channel};
+
+    const CONNECTION_ID: u32 = 1;
+    const MALFORMED_JSON: &str = "{not valid json";
+
+    fn first_job(job_id: &str) -> Notify<'static> {
+        Notify {
+            job_id: job_id.to_string(),
+            prev_hash: PrevHash::try_from("0".repeat(64).as_str()).unwrap(),
+            coin_base1: "ffff".try_into().unwrap(),
+            coin_base2: "ffff".try_into().unwrap(),
+            merkle_branch: vec![MerkleNode::try_from(vec![1_u8; 32]).unwrap()],
+            version: HexU32Be(5667),
+            bits: HexU32Be(5678),
+            time: HexU32Be(5609),
+            clean_jobs: true,
+        }
+    }
+
+    async fn test_receive_fixture() -> (
+        Arc<Mutex<Downstream>>,
+        Arc<Mutex<TaskManager>>,
+        tokio::sync::mpsc::Sender<String>,
+        tokio::sync::mpsc::Receiver<String>,
+        tokio::sync::mpsc::Receiver<Message>,
+        StatsSender,
+    ) {
+        let mut current_difficulties = VecDeque::new();
+        current_difficulties.push_back(1.0);
+        let difficulty_mgmt = DownstreamDifficultyConfig {
+            estimated_downstream_hash_rate: 1.0,
+            submits: VecDeque::new(),
+            pid_controller: Pid::new(*crate::SHARE_PER_MIN, 10.0),
+            current_difficulties,
+            initial_difficulty: 1.0,
+            hard_minimum_difficulty: None,
+        };
+        let (upstream_config, _rx) =
+            UpstreamDifficultyConfig::new(crate::CHANNEL_DIFF_UPDTATE_INTERVAL, 0.0);
+        let (tx_sv1_submit, _rx_sv1_submit) = channel::<DownstreamMessages>(8);
+        let (tx_outgoing, rx_outgoing) = channel(8);
+        let (tx_update_token, _rx_update_token) = channel(8);
+        let stats_sender = StatsSender::new();
+        stats_sender
+            .setup_stats_reliable(CONNECTION_ID)
+            .await
+            .unwrap();
+
+        let downstream = Arc::new(Mutex::new(Downstream::new(
+            CONNECTION_ID,
+            vec![],
+            vec![],
+            None,
+            None,
+            tx_sv1_submit,
+            tx_outgoing,
+            4,
+            difficulty_mgmt,
+            Arc::new(Mutex::new(upstream_config)),
+            stats_sender.clone(),
+            first_job("42"),
+            tx_update_token,
+        )));
+        let task_manager = TaskManager::initialize();
+        let (tx_incoming, rx_incoming) = channel(8);
+
+        (
+            downstream,
+            task_manager,
+            tx_incoming,
+            rx_incoming,
+            rx_outgoing,
+            stats_sender,
+        )
+    }
+
+    async fn wait_until_closed(downstream: &Arc<Mutex<Downstream>>) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if downstream.safe_lock(|d| d.is_closed()).unwrap() {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("downstream did not close in time");
+    }
+
+    #[tokio::test]
+    async fn malformed_json_triggers_full_teardown() {
+        let (
+            downstream,
+            task_manager,
+            tx_incoming,
+            rx_incoming,
+            _rx_outgoing,
+            stats_sender,
+        ) = test_receive_fixture().await;
+
+        let bootstrap_handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        let bootstrap_abort = bootstrap_handle.abort_handle();
+        TaskManager::add_bootstrap(
+            task_manager.clone(),
+            bootstrap_handle.into(),
+            CONNECTION_ID,
+        )
+        .await
+        .unwrap();
+
+        start_receive_downstream(
+            task_manager.clone(),
+            downstream.clone(),
+            rx_incoming,
+            CONNECTION_ID,
+        )
+        .await
+        .unwrap();
+
+        tx_incoming
+            .send(MALFORMED_JSON.to_string())
+            .await
+            .unwrap();
+        drop(tx_incoming);
+
+        wait_until_closed(&downstream).await;
+
+        assert!(
+            downstream.safe_lock(|d| d.is_closed()).unwrap(),
+            "downstream must be marked closed after malformed JSON"
+        );
+
+        let stats = stats_sender.collect_stats().await.unwrap();
+        assert!(
+            !stats.contains_key(&CONNECTION_ID),
+            "stats entry must be removed after malformed JSON teardown"
+        );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            bootstrap_abort.is_finished(),
+            "kill signal must abort registered bootstrap tasks for the connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_json_races_deferred_bootstrap() {
+        let (
+            downstream,
+            task_manager,
+            tx_incoming,
+            rx_incoming,
+            mut rx_outgoing,
+            stats_sender,
+        ) = test_receive_fixture().await;
+
+        start_receive_downstream(
+            task_manager.clone(),
+            downstream.clone(),
+            rx_incoming,
+            CONNECTION_ID,
+        )
+        .await
+        .unwrap();
+
+        tx_incoming
+            .send(MALFORMED_JSON.to_string())
+            .await
+            .unwrap();
+        drop(tx_incoming);
+
+        wait_until_closed(&downstream).await;
+
+        let stats = stats_sender.collect_stats().await.unwrap();
+        assert!(
+            !stats.contains_key(&CONNECTION_ID),
+            "teardown must remove stats before bootstrap can observe a live session"
+        );
+
+        let (_tx_notify, rx_notify) = broadcast::channel(8);
+        let bootstrap = tokio::spawn({
+            let downstream = downstream.clone();
+            let task_manager = task_manager.clone();
+            async move {
+                let should_skip_bootstrap = downstream.safe_lock(|d| d.is_closed()).unwrap();
+                if should_skip_bootstrap {
+                    return;
+                }
+
+                start_notify(
+                    task_manager,
+                    downstream,
+                    rx_notify,
+                    "127.0.0.1".to_string(),
+                    CONNECTION_ID,
+                )
+                .await
+                .unwrap();
+            }
+        });
+        bootstrap.await.unwrap();
+
+        let stats = stats_sender.collect_stats().await.unwrap();
+        assert!(
+            !stats.contains_key(&CONNECTION_ID),
+            "deferred bootstrap must not register stats for a closed downstream"
+        );
+
+        assert!(
+            rx_outgoing.try_recv().is_err(),
+            "deferred bootstrap must not enqueue mining.notify for a closed downstream"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Eagerly call `mark_closed()` at the malformed-JSON break site in the SV1 downstream receive loop so deferred bootstrap tasks cannot observe `is_closed == false` for a connection that is already dead.
- Add regression tests proving invalid JSON-RPC input triggers full teardown: closed flag, stats removal, and task-manager kill signal (bootstrap abort).
- Add a sequential deferred-bootstrap test ensuring closed downstreams do not re-register stats or enqueue `mining.notify`.

Fixes #241

## Context

Malformed JSON previously used `return` inside the receive task, which skipped post-loop teardown (`mark_closed`, stats cleanup, kill signal). That was fixed to `break` in 0076242, and notify/bootstrap guards were added in d1c3fb3. This PR closes the remaining race window between `break` and post-loop `mark_closed()`, and locks the behavior in with tests.

## Changes

| File | Change |
|------|--------|
| `src/translator/downstream/receive_from_downstream.rs` | Eager `mark_closed()` on malformed JSON + 2 regression tests |

No changes to `downstream.rs`, `notify.rs`, or bootstrap registration.

## Test plan

- [x] `cargo test malformed_json` — 2 new tests pass
  - `malformed_json_triggers_full_teardown`
  - `malformed_json_races_deferred_bootstrap`
- [x] `cargo test receive_from_downstream`
- [x] `cargo test` — full suite green
- [ ] `cargo clippy -- -D warnings` (CI)
- [ ] `cargo fmt --check` (CI)