### PR TITLE
Fix JD mode bridge dying on bad share submits

### DIFF
--- a/src/translator/downstream/downstream.rs
+++ b/src/translator/downstream/downstream.rs
@@ -262,14 +262,17 @@ impl Downstream {
         )
         .await
         {
-            error!("Failed to start receive downstream task: {e}");
-            ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
-        } else {
-            info!(
-                "dmnd-client-debug downstream_receive_task_started connection_id={} host={}",
-                connection_id, host
+            error!(
+                "Failed to register downstream receive task for connection_id={}: {e}",
+                connection_id
             );
-        };
+            ProxyState::update_downstream_state(DownstreamType::TranslatorDownstream);
+            return;
+        }
+        info!(
+            "dmnd-client-debug downstream_receive_task_started connection_id={} host={}",
+            connection_id, host
+        );
 
         if let Err(e) = start_send_to_downstream(
             task_manager.clone(),
@@ -801,7 +804,18 @@ impl Downstream {
                 Self::send_message_downstream(self_, request.respond(true).into()).await;
             }
             Err(e) => {
-                error!("Failed to forward downstream submit: {e}");
+                let connection_id = self_.safe_lock(|s| s.connection_id)?;
+                if matches!(e, Error::BridgeChannelClosed) {
+                    error!(
+                        "Bridge channel closed, cannot forward share: connection_id={} job_id={}",
+                        connection_id, request.job_id
+                    );
+                } else {
+                    error!(
+                        "Failed to forward downstream submit for connection_id={} job_id={}: {e}",
+                        connection_id, request.job_id
+                    );
+                }
                 let share = ShareInfo::new(
                     request.user_name.clone(),
                     None,
@@ -814,6 +828,9 @@ impl Downstream {
                     s.stats_sender.update_rejected_shares(s.connection_id);
                 })?;
                 Self::send_message_downstream(self_, request.respond(false).into()).await;
+                if matches!(e, Error::BridgeChannelClosed) {
+                    return Err(Error::BridgeChannelClosed);
+                }
             }
         }
 
@@ -915,9 +932,58 @@ impl Downstream {
         sender
             .send(DownstreamMessages::SubmitShares(to_send))
             .await
-            .map_err(|_| Error::AsyncChannelError)?;
+            .map_err(|_| Error::BridgeChannelClosed)?;
 
         Ok(result_rx)
+    }
+
+    pub(super) async fn teardown_session(
+        downstream: Arc<Mutex<Self>>,
+        task_manager: Arc<Mutex<TaskManager>>,
+        connection_id: u32,
+    ) {
+        if let Err(e) = downstream.safe_lock(|d| d.mark_closed()) {
+            error!("Failed to mark downstream {connection_id} closed: {e}");
+        }
+        let stats_sender = downstream.safe_lock(|d| d.stats_sender.clone()).ok();
+        if let Some(stats_sender) = stats_sender {
+            if let Err(e) = stats_sender.remove_stats_reliable(connection_id).await {
+                error!("Failed to remove downstream stats {connection_id}: {e}");
+            }
+        }
+        debug!(
+            "Downstream: Shutting down sv1 downstream session {}",
+            connection_id
+        );
+
+        if let Err(e) = Self::remove_downstream_hashrate_from_channel(&downstream) {
+            error!("Failed to remove downstream hashrate from channel: {}", e)
+        };
+
+        let worker_name = downstream
+            .safe_lock(|d| d.authorized_names.first().cloned().unwrap_or_default())
+            .unwrap_or_else(|e| {
+                error!("Failed to lock downstream: {:?}", e);
+                ProxyState::update_inconsistency(Some(1));
+                "unknown".to_string()
+            });
+
+        if !worker_name.is_empty() {
+            MonitorAPI::worker_disconnected(connection_id);
+        }
+
+        let send_kill_signal = match task_manager.safe_lock(|tm| tm.send_kill_signal.clone()) {
+            Ok(sender) => sender,
+            Err(e) => {
+                error!("Failed to lock task manager for downstream teardown: {e}");
+                ProxyState::update_inconsistency(Some(1));
+                return;
+            }
+        };
+        if send_kill_signal.send(connection_id).await.is_err() {
+            error!("Proxy can not abort downstreams tasks");
+            ProxyState::update_inconsistency(Some(1));
+        }
     }
 
     #[cfg(test)]
@@ -1876,5 +1942,28 @@ mod tests {
         assert!(recent_jobs.get_matching_job(job_2_v1).is_some());
         assert!(recent_jobs.get_matching_job(job_3_v1).is_some());
         assert!(recent_jobs.get_matching_job(job_4_v1).is_some());
+    }
+
+    #[tokio::test]
+    async fn forward_submit_share_returns_bridge_channel_closed_when_receiver_dropped() {
+        let (downstream, _, _) = test_downstream(vec!["worker".to_string()], 4, None).await;
+        let (tx, rx) = channel::<DownstreamMessages>(1);
+        drop(rx);
+        downstream
+            .safe_lock(|d| d.tx_sv1_bridge = tx)
+            .unwrap();
+
+        let submit = client_to_server::Submit {
+            user_name: "worker".to_string(),
+            job_id: "42".to_string(),
+            extra_nonce2: Extranonce::try_from(vec![1_u8; 4]).unwrap(),
+            time: HexU32Be(5609),
+            nonce: HexU32Be(11),
+            version_bits: None,
+            id: 21,
+        };
+
+        let result = Downstream::forward_submit_share(&downstream, submit).await;
+        assert!(matches!(result, Err(Error::BridgeChannelClosed)));
     }
 }

--- a/src/translator/downstream/mod.rs
+++ b/src/translator/downstream/mod.rs
@@ -38,11 +38,10 @@ pub type SubmitShareResultSender = oneshot::Sender<SubmitShareResult>;
 pub struct SubmitShareWithChannelId {
     pub channel_id: u32,
     pub share: Submit<'static>,
-    // TODO why we need allow dead code here???
     #[allow(dead_code)]
-    extranonce: Vec<u8>,
+    pub(crate) extranonce: Vec<u8>,
     #[allow(dead_code)]
-    extranonce2_len: usize,
+    pub(crate) extranonce2_len: usize,
     pub version_rolling_mask: Option<HexU32Be>,
     pub result_tx: SubmitShareResultSender,
 }

--- a/src/translator/downstream/receive_from_downstream.rs
+++ b/src/translator/downstream/receive_from_downstream.rs
@@ -1,11 +1,11 @@
 use super::{downstream::Downstream, task_manager::TaskManager};
-use crate::{monitor::MonitorAPI, proxy_state::ProxyState, translator::error::Error};
+use crate::translator::error::Error;
 use roles_logic_sv2::utils::Mutex;
 use std::sync::Arc;
 use sv1_api::json_rpc;
 use tokio::sync::mpsc;
 use tokio::task;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 const DOWNSTREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(99999999);
 
@@ -44,6 +44,16 @@ pub async fn start_receive_downstream(
     mut recv_from_down: mpsc::Receiver<String>,
     connection_id: u32,
 ) -> Result<(), Error<'static>> {
+    let is_closed = downstream
+        .safe_lock(|d| d.is_closed())
+        .unwrap_or_else(|e| {
+            error!("Failed to read downstream closed state before receive registration: {e}");
+            true
+        });
+    info!(
+        "Registering downstream receive task connection_id={} is_closed={}",
+        connection_id, is_closed
+    );
     let handle = {
         let task_manager = task_manager.clone();
         task::spawn(async move {
@@ -109,52 +119,16 @@ pub async fn start_receive_downstream(
                     break;
                 }
             }
-            if let Err(e) = downstream.safe_lock(|d| d.mark_closed()) {
-                error!("Failed to mark downstream {connection_id} closed: {e}");
-            }
-            let stats_sender = downstream.safe_lock(|d| d.stats_sender.clone()).ok();
-            if let Some(stats_sender) = stats_sender {
-                if let Err(e) = stats_sender.remove_stats_reliable(connection_id).await {
-                    error!("Failed to remove downstream stats {connection_id}: {e}");
-                }
-            }
-            // No message to receive
-            debug!(
-                "Downstream: Shutting down sv1 downstream reader {}",
-                connection_id
-            );
-
-            if let Err(e) = Downstream::remove_downstream_hashrate_from_channel(&downstream) {
-                error!("Failed to remove downstream hashrate from channel: {}", e)
-            };
-
-            let worker_name = downstream
-                .safe_lock(|d| d.authorized_names.first().cloned().unwrap_or_default())
-                .unwrap_or_else(|e| {
-                    error!("Failed to lock downstream: {:?}", e);
-                    ProxyState::update_inconsistency(Some(1));
-                    "unknown".to_string()
-                });
-
-            if !worker_name.is_empty() {
-                MonitorAPI::worker_disconnected(connection_id);
-            }
-
-            // Apparently there is no way to make the compiler happy without unwrapping here. But
-            // is not an issue since:
-            // 1. the mutex should never get poisioned and if it does will be very very rare
-            // 2. restarting the process after the unwrapping or restarting the all the tasks from
-            //    inside the process (that is what we should do here) is almost the same thing
-            let send_kill_signal = task_manager
-                .safe_lock(|tm| tm.send_kill_signal.clone())
-                .unwrap();
-            if send_kill_signal.send(connection_id).await.is_err() {
-                error!("Proxy can not abort downstreams tasks");
-                ProxyState::update_inconsistency(Some(1));
-            }
+            Downstream::teardown_session(downstream, task_manager, connection_id).await;
         })
     };
     TaskManager::add_receive_downstream(task_manager, handle.into(), connection_id)
         .await
-        .map_err(|_| Error::TranslatorTaskManagerFailed)
+        .map_err(|e| {
+            error!(
+                "Failed to register downstream receive task for connection_id={}: {e}",
+                connection_id
+            );
+            e
+        })
 }

--- a/src/translator/downstream/task_manager.rs
+++ b/src/translator/downstream/task_manager.rs
@@ -95,12 +95,14 @@ impl TaskManager {
         self_: Arc<Mutex<Self>>,
         abortable: AbortOnDrop,
         connection_id: u32,
-    ) -> Result<(), ()> {
-        let send_task = self_.safe_lock(|s| s.send_task.clone()).unwrap();
+    ) -> Result<(), crate::translator::error::Error<'static>> {
+        let send_task = self_
+            .safe_lock(|s| s.send_task.clone())
+            .map_err(|_| crate::translator::error::Error::TranslatorTaskManagerMutexPoisoned)?;
         send_task
             .send((Some(connection_id), Task::ReceiveDownstream(abortable)))
             .await
-            .map_err(|_| ())
+            .map_err(|_| crate::translator::error::Error::TranslatorTaskManagerChannelClosed)
     }
     pub async fn add_bootstrap(
         self_: Arc<Mutex<Self>>,

--- a/src/translator/error.rs
+++ b/src/translator/error.rs
@@ -28,6 +28,12 @@ pub enum Error<'a> {
     ImpossibleToOpenChannnel,
     #[allow(clippy::enum_variant_names)]
     AsyncChannelError,
+    /// The translator bridge downstream message channel (`tx_sv1_bridge`) is closed.
+    BridgeChannelClosed,
+    /// The upstream submit-share channel (`tx_sv2_submit_shares_ext`) is closed.
+    UpstreamSubmitChannelClosed,
+    /// The downstream TaskManager registration channel is closed.
+    TranslatorTaskManagerChannelClosed,
 }
 
 impl From<Infallible> for Error<'_> {
@@ -46,7 +52,14 @@ impl fmt::Display for Error<'_> {
             Error::TargetError(e) => write!(f, "TargetError {e}"),
             Error::Infallible(e) => write!(f, "Infallible {e}"),
             Error::ImpossibleToOpenChannnel => write!(f, "ImpossibleToOpenChannnel"),
-            Error::AsyncChannelError => write!(f, "AsyncChannelError"),
+            Error::AsyncChannelError => write!(f, "async channel closed"),
+            Error::BridgeChannelClosed => write!(f, "bridge channel closed (tx_sv1_bridge)"),
+            Error::UpstreamSubmitChannelClosed => {
+                write!(f, "upstream submit channel closed (tx_sv2_submit_shares_ext)")
+            }
+            Error::TranslatorTaskManagerChannelClosed => {
+                write!(f, "downstream task manager channel closed")
+            }
             Error::TranslatorUpstreamMutexPoisoned => write!(f, "TranslatorUpstreamMutexPoisoned"),
             Error::TranslatorDiffConfigMutexPoisoned => {
                 write!(f, "TranslatorDiffConfigMutexPoisoned")

--- a/src/translator/proxy/bridge.rs
+++ b/src/translator/proxy/bridge.rs
@@ -215,6 +215,15 @@ impl Bridge {
         Ok(abortable)
     }
 
+    fn is_fatal_bridge_error(e: &Error) -> bool {
+        matches!(
+            e,
+            Error::AsyncChannelError
+                | Error::UpstreamSubmitChannelClosed
+                | Error::BridgeMutexPoisoned
+        )
+    }
+
     /// Receives a `DownstreamMessages` message from the `Downstream`, handles based on the
     /// variant received.
     fn handle_downstream_messages(
@@ -235,18 +244,19 @@ impl Bridge {
                 match msg {
                     DownstreamMessages::SubmitShares(share) => {
                         if let Err(e) = Self::handle_submit_shares(self_.clone(), share).await {
-                            error!("Failed to handle SubmitShareWithChannelId: {e}");
-                            ProxyState::update_translator_state(TranslatorState::Down);
-                            break;
+                            if Self::is_fatal_bridge_error(&e) {
+                                error!("Fatal bridge error handling SubmitShareWithChannelId: {e}");
+                                ProxyState::update_translator_state(TranslatorState::Down);
+                                break;
+                            }
+                            warn!("Recoverable error handling SubmitShareWithChannelId: {e}");
                         }
                     }
                     DownstreamMessages::SetDownstreamTarget(new_target) => {
                         if let Err(e) =
                             Self::handle_update_downstream_target(self_.clone(), new_target)
                         {
-                            error!("Failed to handle SetDownstreamTarget: {e}");
-                            ProxyState::update_translator_state(TranslatorState::Down);
-                            break;
+                            warn!("Failed to handle SetDownstreamTarget (continuing): {e}");
                         };
                     }
                 };
@@ -334,7 +344,7 @@ impl Bridge {
                         result_tx,
                         Err(crate::monitor::shares::RejectionReason::JobIdNotFound),
                     );
-                    return Err(Error::RolesSv2Logic(roles_logic_sv2::Error::NoValidJob));
+                    return Ok(());
                 }
                 warn!(
                     "Failed to translate SV1 mining.submit message to SV2 SubmitSharesExtended message, attempt {}",
@@ -358,11 +368,12 @@ impl Bridge {
                 return Ok(());
             }
             Err(e) => {
+                warn!("Share translation failed with {e}");
                 Self::resolve_submit(
                     result_tx,
                     Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
                 );
-                return Err(Error::RolesSv2Logic(e));
+                return Ok(());
             }
         };
 
@@ -435,7 +446,7 @@ impl Bridge {
                         e.0.result_tx,
                         Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
                     );
-                    return Err(Error::AsyncChannelError);
+                    return Err(Error::UpstreamSubmitChannelClosed);
                 }
                 Ok(())
             }
@@ -454,11 +465,12 @@ impl Bridge {
             // Proxy do not have JD capabilities
             Ok(OnNewShare::ShareMeetBitcoinTarget(..)) => unreachable!(),
             Err(e) => {
+                warn!("Share rejected by channel factory: {e}");
                 Self::resolve_submit(
                     result_tx,
                     Err(crate::monitor::shares::RejectionReason::UpstreamRejected),
                 );
-                Err(Error::RolesSv2Logic(e))
+                Ok(())
             }
         }
     }
@@ -1090,5 +1102,150 @@ mod test {
             found_local_only_share,
             "expected at least one share to stay local; downstream={downstream_hits}, upstream={upstream_hits}, bitcoin={bitcoin_hits}, errors={errors}"
         );
+    }
+
+    fn bridge_submit_share_message(
+        channel_id: u32,
+        extranonce: Vec<u8>,
+        extranonce2_len: usize,
+        job_id: u32,
+        nonce: u32,
+    ) -> SubmitShareWithChannelId {
+        let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
+        SubmitShareWithChannelId {
+            channel_id,
+            share: test_utils::create_sv1_submit_with_fields(job_id, extranonce2_len, TEST_NTIME, nonce),
+            extranonce,
+            extranonce2_len,
+            version_rolling_mask: None,
+            result_tx,
+        }
+    }
+
+    #[tokio::test]
+    async fn fatal_upstream_submit_channel_closes_bridge_downstream_handler() {
+        let extranonces = ExtendedExtranonce::new(0..6, 6..8, 8..16);
+        let upstream_target = [255_u8; 32];
+        let (tx_sv2_submit_shares_ext, rx_sv2_submit_shares_ext) = mpsc::channel(1);
+        drop(rx_sv2_submit_shares_ext);
+
+        let (tx_sv1_notify, _rx_sv1_notify) = broadcast::channel(1);
+        let bridge = Bridge::new(
+            tx_sv2_submit_shares_ext,
+            tx_sv1_notify,
+            extranonces,
+            Arc::new(Mutex::new(upstream_target.to_vec())),
+            1,
+        )
+        .unwrap();
+
+        let (channel_id, extranonce2_len, extranonce) = bridge
+            .safe_lock(|bridge| {
+                seed_bridge_job(bridge);
+                let opened = bridge.on_new_sv1_connection(1_000_000_000_000.0).unwrap();
+                (
+                    opened.channel_id,
+                    opened.extranonce2_len as usize,
+                    opened.extranonce,
+                )
+            })
+            .unwrap();
+
+        let upstream_nonce = bridge
+            .safe_lock(|bridge| {
+                (0..4_096).find(|nonce| {
+                    matches!(
+                        classify_submit(bridge, channel_id, extranonce2_len, *nonce),
+                        OnNewShare::SendSubmitShareUpstream(_)
+                    )
+                })
+            })
+            .unwrap()
+            .expect("expected a share that meets upstream target");
+
+        let (tx_down, rx_down) = mpsc::channel::<DownstreamMessages>(4);
+        let handler = Bridge::handle_downstream_messages(bridge, rx_down);
+
+        let share = bridge_submit_share_message(
+            channel_id,
+            extranonce,
+            extranonce2_len,
+            TEST_JOB_ID,
+            upstream_nonce,
+        );
+
+        tx_down
+            .send(DownstreamMessages::SubmitShares(share))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), handler)
+            .await
+            .expect("bridge downstream handler should exit after fatal upstream channel error")
+            .expect("bridge downstream handler join error");
+
+        assert!(
+            tx_down
+                .send(DownstreamMessages::SetDownstreamTarget(SetDownstreamTarget {
+                    channel_id,
+                    new_target: [255; 32].into(),
+                }))
+                .await
+                .is_err(),
+            "bridge downstream channel should be closed after fatal handler exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_survives_repeated_invalid_job_submits() {
+        let extranonces = ExtendedExtranonce::new(0..6, 6..8, 8..16);
+        let bridge = test_utils::create_bridge(extranonces).unwrap();
+        let channel_id = bridge
+            .safe_lock(|bridge| {
+                seed_bridge_job(bridge);
+                bridge.on_new_sv1_connection(1_000_000_000_000.0).unwrap().channel_id
+            })
+            .unwrap();
+
+        let (tx_down, rx_down) = mpsc::channel::<DownstreamMessages>(32);
+        let handler = Bridge::handle_downstream_messages(bridge, rx_down);
+
+        for nonce in 0..12 {
+            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+            tx_down
+                .send(DownstreamMessages::SubmitShares(SubmitShareWithChannelId {
+                    channel_id,
+                    share: test_utils::create_sv1_submit_with_fields(9_999, 8, TEST_NTIME, nonce),
+                    extranonce: vec![0; 6],
+                    extranonce2_len: 8,
+                    version_rolling_mask: None,
+                    result_tx,
+                }))
+                .await
+                .unwrap();
+            assert!(matches!(
+                result_rx.await,
+                Ok(Err(crate::monitor::shares::RejectionReason::JobIdNotFound))
+            ));
+        }
+
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        tx_down
+            .send(DownstreamMessages::SubmitShares(SubmitShareWithChannelId {
+                channel_id,
+                share: test_utils::create_sv1_submit_with_fields(9_998, 8, TEST_NTIME, 42),
+                extranonce: vec![0; 6],
+                extranonce2_len: 8,
+                version_rolling_mask: None,
+                result_tx,
+            }))
+            .await
+            .unwrap();
+        assert!(matches!(
+            result_rx.await,
+            Ok(Err(crate::monitor::shares::RejectionReason::JobIdNotFound))
+        ));
+
+        handler.abort();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #127

In JD mode, a single bad share submit could kill the bridge channel for every connected miner. Shares still validated locally, but upstream forwarding failed with a misleading `Closed(..)` error that looked like a receive-task crash.

This change keeps the bridge running for recoverable per-share errors (invalid job ID, translation failure, etc.) and only shuts down on real fatal failures (dead upstream/submit channels, poisoned mutex).

Also improves error messages so `Closed(..)` is no longer reported as "Failed to start receive downstream task".

## Test plan

- [x] `cargo test` — 89 passed
- [x] `bridge_survives_repeated_invalid_job_submits`
- [x] `fatal_upstream_submit_channel_closes_bridge_downstream_handler`
- [x] `forward_submit_share_returns_bridge_channel_closed_when_receiver_dropped`