### PR TITLE
Add deprioritizing transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ curl -X POST \
 | Normal (`0`) | Prioritized (`+RPC_FEE_DELTA`) | No change |
 | Prioritized (`+RPC_FEE_DELTA`) | No change | Normal (`0`) |
 
-The client reads the current cumulative delta from Bitcoin Core before applying an action. It only accepts the two states above and never applies a transition that creates a negative fee delta.
+The client reads the current cumulative delta from Bitcoin Core before applying an action. It only accepts the two states above and never applies a transition that creates a negative fee delta. The `+` action submits the raw transaction to the node before prioritizing it; the `-` action derives the txid locally and never submits the transaction.
 
 List currently tracked prioritized transactions:
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Log in with the credentials you used during registration.
 
 ## 7. Prioritize and Deprioritize Transactions (optional)
 
-The DMND Client can expose an API endpoint that submits a raw transaction to your Bitcoin Core node and asks it to prioritize or deprioritize that transaction for block template selection (via the `prioritisetransaction` RPC).
+The DMND Client can expose an API endpoint that prioritizes or deprioritizes a transaction for block template selection (via the `prioritisetransaction` RPC), conditionally submitting the raw transaction to your Bitcoin Core node when prioritizing it.
 
 The feature is enabled only when all of the following are configured:
 
@@ -280,7 +280,7 @@ curl -X POST \
 | Normal (`0`) | Prioritized (`+RPC_FEE_DELTA`) | No change |
 | Prioritized (`+RPC_FEE_DELTA`) | No change | Normal (`0`) |
 
-The client reads the current cumulative delta from Bitcoin Core before applying an action. It only accepts the two states above and never applies a transition that creates a negative fee delta. The `+` action submits the raw transaction to the node before prioritizing it; the `-` action derives the txid locally and never submits the transaction.
+The client reads the current cumulative delta from Bitcoin Core before applying an action. It only accepts the two states above and never applies a transition that creates a negative fee delta. For the `+` action, the client applies the priority delta first, then checks the mempool and submits the raw transaction only when it is not already present. This lets Bitcoin Core evaluate a newly submitted transaction using its modified fee. The `-` action derives the txid locally and never submits the transaction.
 
 List currently tracked prioritized transactions:
 

--- a/README.md
+++ b/README.md
@@ -214,21 +214,21 @@ Log in with the credentials you used during registration.
 
 > Hashrate statistics are averaged over time — the dashboard typically reflects your full hashrate well within the first hour after your miners connect. A low reading right after connecting is normal.
 
-## 7. Prioritize Transactions (optional)
+## 7. Prioritize and Deprioritize Transactions (optional)
 
-The DMND Client can expose an API endpoint that submits a raw transaction to your Bitcoin Core node and asks it to prioritize that transaction for block template selection (via the `prioritisetransaction` RPC).
+The DMND Client can expose an API endpoint that submits a raw transaction to your Bitcoin Core node and asks it to prioritize or deprioritize that transaction for block template selection (via the `prioritisetransaction` RPC).
 
-The feature is enabled **only when all** of the following are configured:
+The feature is enabled only when all of the following are configured:
 
 | Setting | CLI flag | config.toml | Env var | Description |
 |---|---|---|---|---|
 | RPC URL | `--rpc-url` | `rpc_url` | `RPC_URL` | Bitcoin Core RPC, e.g. `http://127.0.0.1:8332` |
 | RPC user | `--rpc-user` | `rpc_user` | `RPC_USER` | Bitcoin Core RPC username |
 | RPC password | `--rpc-pwd` | `rpc_pwd` | `RPC_PWD` | Bitcoin Core RPC password |
-| Fee delta | `--rpc-fee-delta` | `rpc_fee_delta` | `RPC_FEE_DELTA` | Virtual fee boost **in satoshis**, passed to `prioritisetransaction` |
+| Fee delta | `--rpc-fee-delta` | `rpc_fee_delta` | `RPC_FEE_DELTA` | Positive prioritization amount **in satoshis**, e.g. `100000000` (1 BTC) |
 | API token | `--api-tx-token` | `api_tx_token` | `API_TX_TOKEN` | Bearer token required by this API |
 
-> **Fee delta units:** `RPC_FEE_DELTA` is denominated in **satoshis**. It's a *virtual* fee adjustment used only for template selection on your node — it doesn't spend anything — but set it deliberately. `100000` (0.001 BTC virtual boost) is a reasonable starting point.
+> **Fee delta units:** `RPC_FEE_DELTA` is a positive magnitude denominated in **satoshis**. For example, configure `100000000` for a 1 BTC virtual adjustment. Prioritizing adds that amount for template selection on your node; deprioritizing removes it from an already-prioritized transaction. It doesn't spend anything.
 
 > **Security:**
 > - The tx API (default port **3001**) should never be exposed to the public internet. Bind it to localhost or protect it behind your own gateway.
@@ -242,7 +242,7 @@ TOKEN=<DMND-token> \
 RPC_URL=http://127.0.0.1:8332 \
 RPC_USER=<bitcoin-rpc-user> \
 RPC_PWD=<bitcoin-rpc-password> \
-RPC_FEE_DELTA=100000 \
+RPC_FEE_DELTA=100000000 \
 API_TX_TOKEN=<api-token> \
 ./dmnd-client -l info -d 250T --tp-address="127.0.0.1:8336"
 ```
@@ -253,19 +253,34 @@ Example `config.toml`:
 rpc_url = "http://127.0.0.1:8332"
 rpc_user = "<bitcoin-rpc-user>"
 rpc_pwd = "<bitcoin-rpc-password>"
-rpc_fee_delta = 100000
+rpc_fee_delta = 100000000
 api_tx_token = "<api-token>"
 ```
 
 ### Using the API
 
-Submit a raw transaction hex:
+Use `+` to prioritize a transaction:
 
 ```
 curl -X POST \
   -H "Authorization: Bearer <api-token>" \
-  "http://127.0.0.1:3001/api/tx/submit/<raw-transaction-hex>"
+  "http://127.0.0.1:3001/api/tx/submit/+/<raw-transaction-hex>"
 ```
+
+Use `-` to restore a prioritized transaction to its original fee rate:
+
+```
+curl -X POST \
+  -H "Authorization: Bearer <api-token>" \
+  "http://127.0.0.1:3001/api/tx/submit/-/<raw-transaction-hex>"
+```
+
+| Current state | `+` action | `-` action |
+|---|---|---|
+| Normal (`0`) | Prioritized (`+RPC_FEE_DELTA`) | No change |
+| Prioritized (`+RPC_FEE_DELTA`) | No change | Normal (`0`) |
+
+The client reads the current cumulative delta from Bitcoin Core before applying an action. It only accepts the two states above and never applies a transition that creates a negative fee delta.
 
 List currently tracked prioritized transactions:
 
@@ -289,7 +304,7 @@ The response includes the tracked transaction count, transaction hex, and live m
         "tx_hex": "<raw-transaction-hex>",
         "tx_fee": {
           "real": 0.00001000,
-          "modified": 0.00101000
+          "modified": 1.00001000
         }
       }
     ]
@@ -311,7 +326,7 @@ If the prioritization configuration is incomplete, these endpoints are disabled:
 | Miner connects but no shares yet | Normal within the first ~6 min | Wait; first share acceptance takes about 6 minutes |
 | Still no shares after 10+ min | Wrong token in password field, or `-d` far off | Re-check token; set `-d` to your least powerful machine (250T direct / 20P proxies) |
 | Dashboard shows zero / low hashrate | Statistics lag | Give it up to an hour after connecting |
-| tx API returns 503 | Prioritization config incomplete | All five settings in Section 7 must be set |
+| tx API returns 503 | Prioritization config incomplete | Set all five prioritization settings from Section 7 |
 
 Still stuck? Reach out through the support channel listed in your registration confirmation email.
 

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -3,6 +3,7 @@ use bitcoin::{blockdata::transaction::Transaction, consensus::encode::deserializ
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{error::Error as StdError, fmt, time::Duration};
+use tokio::sync::Mutex;
 use tracing::{debug, info};
 
 const RPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -13,6 +14,7 @@ pub(crate) struct BitcoindRpc {
     user: String,
     pwd: String,
     fee_delta: i64,
+    priority_transition_lock: Mutex<()>,
 }
 
 impl BitcoindRpc {
@@ -22,10 +24,18 @@ impl BitcoindRpc {
             user,
             pwd,
             fee_delta,
+            priority_transition_lock: Mutex::new(()),
         }
     }
 
-    pub(crate) async fn submit_transaction(&self, tx: &str) -> Result<String, BitcoindRpcError> {
+    pub(crate) async fn submit_transaction(
+        &self,
+        tx: &str,
+        prioritize: bool,
+    ) -> Result<String, BitcoindRpcError> {
+        // Serialize state reads and mutations so concurrent API calls cannot move a transaction
+        // outside the two supported states.
+        let _transition_guard = self.priority_transition_lock.lock().await;
         let tx = validate_transaction_hex(tx)?;
         let transaction = transaction_from_hex(tx)?;
         let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
@@ -37,21 +47,104 @@ impl BitcoindRpc {
             )));
         }
 
-        self.prioritise_transaction(&txid).await?;
-        crate::prioritized_transactions::record(transaction);
+        let current_delta = self.current_fee_delta(&txid).await?;
+        let delta_to_apply = self.priority_delta(current_delta, prioritize)?;
+        let next_delta = current_delta + delta_to_apply;
+
+        if delta_to_apply != 0 {
+            self.prioritise_transaction(&txid, delta_to_apply).await?;
+        } else {
+            info!(
+                txid = %txid,
+                prioritize,
+                "transaction priority action is already at its boundary; no fee delta applied"
+            );
+        }
+
+        if next_delta == self.fee_delta {
+            crate::prioritized_transactions::record(transaction);
+        } else {
+            crate::prioritized_transactions::remove(&txid);
+        }
+
+        info!(
+            txid = %txid,
+            prioritize,
+            current_delta,
+            delta_to_apply,
+            next_delta,
+            "transaction priority state updated"
+        );
         Ok(txid.to_string())
     }
 
-    async fn prioritise_transaction(&self, txid: &Txid) -> Result<(), BitcoindRpcError> {
+    /// Calculates the adjustment needed to move between the only two supported states:
+    ///
+    /// | Current cumulative delta | Prioritize | Deprioritize |
+    /// |--------------------------|------------|--------------|
+    /// | `0`                      | `+fee_delta` | no-op       |
+    /// | `fee_delta`              | no-op        | `-fee_delta` |
+    ///
+    /// The negative return value is only an adjustment that restores a prioritized
+    /// transaction to zero. A negative cumulative fee delta is never a valid state.
+    fn priority_delta(
+        &self,
+        current_delta: i64,
+        prioritize: bool,
+    ) -> Result<i64, BitcoindRpcError> {
+        if ![0, self.fee_delta].contains(&current_delta) {
+            return Err(BitcoindRpcError::Prioritize(format!(
+                "transaction has unsupported fee delta {current_delta}; expected 0 or {}",
+                self.fee_delta
+            )));
+        }
+
+        Ok(match (current_delta, prioritize) {
+            (0, true) => self.fee_delta,
+            (current_delta, false) if current_delta == self.fee_delta => -self.fee_delta,
+            _ => 0,
+        })
+    }
+
+    async fn current_fee_delta(&self, txid: &Txid) -> Result<i64, BitcoindRpcError> {
+        let (status, text) = self
+            .send_request("getprioritisedtransactions", json!([]))
+            .await?;
+        let result = RpcResponse::from_response(status, &text)
+            .map_err(|e| BitcoindRpcError::Prioritize(e.to_string()))?
+            .ok_or_else(|| {
+                BitcoindRpcError::InvalidResponse(format!(
+                    "missing getprioritisedtransactions result from bitcoind: {text}"
+                ))
+            })?;
+        let Some(priority) = result.get(txid.to_string()) else {
+            return Ok(0);
+        };
+
+        priority
+            .get("fee_delta")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| {
+                BitcoindRpcError::InvalidResponse(format!(
+                    "missing or invalid fee_delta for transaction {txid}: {text}"
+                ))
+            })
+    }
+
+    async fn prioritise_transaction(
+        &self,
+        txid: &Txid,
+        fee_delta: i64,
+    ) -> Result<(), BitcoindRpcError> {
         let (status, text) = self
             .send_request(
                 "prioritisetransaction",
-                json!([txid.to_string(), 0, self.fee_delta]),
+                json!([txid.to_string(), 0, fee_delta]),
             )
             .await?;
         info!(
             txid = %txid,
-            fee_delta = self.fee_delta,
+            fee_delta,
             %status,
             response = %text,
             "bitcoind prioritisetransaction response"
@@ -393,6 +486,14 @@ mod tests {
                         "id": "dmnd-client"
                     })),
                 ),
+                Some("getprioritisedtransactions") => (
+                    StatusCode::OK,
+                    Json(json!({
+                        "result": {},
+                        "error": null,
+                        "id": "dmnd-client"
+                    })),
+                ),
                 Some("prioritisetransaction") => (
                     StatusCode::OK,
                     Json(json!({
@@ -440,7 +541,7 @@ mod tests {
         );
 
         let txid = rpc
-            .submit_transaction(RAW_TX)
+            .submit_transaction(RAW_TX, true)
             .await
             .expect("already-in-mempool tx should still be prioritized");
 
@@ -451,6 +552,12 @@ mod tests {
             .await
             .expect("sendrawtransaction request");
         assert_eq!(submit_request["method"], "sendrawtransaction");
+
+        let priorities_request = received_requests
+            .recv()
+            .await
+            .expect("getprioritisedtransactions request");
+        assert_eq!(priorities_request["method"], "getprioritisedtransactions");
 
         let prioritize_request = received_requests
             .recv()
@@ -463,6 +570,32 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[test]
+    fn transaction_priority_actions_only_toggle_between_zero_and_configured_delta() {
+        let rpc = BitcoindRpc::new(
+            "http://127.0.0.1:8332".to_string(),
+            "user".to_string(),
+            "password".to_string(),
+            100_000_000,
+        );
+        let cases = [
+            (0, true, 100_000_000),
+            (100_000_000, true, 0),
+            (100_000_000, false, -100_000_000),
+            (0, false, 0),
+        ];
+
+        for (current_delta, prioritize, expected_delta) in cases {
+            assert_eq!(
+                rpc.priority_delta(current_delta, prioritize).unwrap(),
+                expected_delta
+            );
+        }
+        assert!(rpc.priority_delta(-100_000_000, true).is_err());
+        assert!(rpc.priority_delta(-100_000_000, false).is_err());
+        assert!(rpc.priority_delta(1, true).is_err());
     }
 }
 

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -40,19 +40,6 @@ impl BitcoindRpc {
         let transaction = transaction_from_hex(tx)?;
         let txid = transaction.compute_txid();
 
-        // Prioritizing may introduce a new transaction to the node. Deprioritizing only
-        // reverses an existing virtual fee adjustment, so it must never submit the transaction.
-        if prioritize {
-            let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
-            let submitted_txid =
-                txid_from_sendrawtransaction_response(&transaction, status, &text)?;
-            if submitted_txid != txid {
-                return Err(BitcoindRpcError::InvalidResponse(format!(
-                    "bitcoind returned txid {submitted_txid}, but transaction hex decodes to {txid}"
-                )));
-            }
-        }
-
         let current_delta = self.current_fee_delta(&txid).await?;
         let delta_to_apply = self.priority_delta(current_delta, prioritize)?;
         let next_delta = current_delta + delta_to_apply;
@@ -65,6 +52,20 @@ impl BitcoindRpc {
                 prioritize,
                 "transaction priority action is already at its boundary; no fee delta applied"
             );
+        }
+
+        // Bitcoin Core remembers a priority delta even when the transaction is not in its
+        // mempool. Apply the delta first so a low-fee transaction is evaluated with its
+        // modified fee when submitted. Deprioritizing never submits the transaction.
+        if prioritize && !self.transaction_in_mempool(&txid.to_string()).await? {
+            let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
+            let submitted_txid =
+                txid_from_sendrawtransaction_response(&transaction, status, &text)?;
+            if submitted_txid != txid {
+                return Err(BitcoindRpcError::InvalidResponse(format!(
+                    "bitcoind returned txid {submitted_txid}, but transaction hex decodes to {txid}"
+                )));
+            }
         }
 
         if next_delta == self.fee_delta {
@@ -289,7 +290,7 @@ fn txid_from_sendrawtransaction_response(
             info!(
                 txid = %txid,
                 response = %text,
-                "transaction already in bitcoind mempool; prioritizing existing transaction"
+                "transaction already in bitcoind mempool after its priority was applied"
             );
             return Ok(txid);
         }
@@ -405,7 +406,10 @@ mod tests {
     use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
     use serde_json::json;
     use serde_json::Value;
-    use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+    use tokio::{
+        sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        task::JoinHandle,
+    };
 
     const RAW_TX: &str = concat!(
         "01000000",
@@ -419,6 +423,117 @@ mod tests {
         "00",
         "00000000",
     );
+
+    #[derive(Clone)]
+    struct MockPrioritizeState {
+        requests: UnboundedSender<Value>,
+        expected_txid: String,
+        transaction_in_mempool: bool,
+    }
+
+    async fn mock_prioritize_bitcoind(
+        State(state): State<MockPrioritizeState>,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        let method = body
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        state
+            .requests
+            .send(body)
+            .expect("test should receive bitcoind request");
+
+        match method.as_deref() {
+            Some("getprioritisedtransactions") => (
+                StatusCode::OK,
+                Json(json!({
+                    "result": {},
+                    "error": null,
+                    "id": "dmnd-client"
+                })),
+            ),
+            Some("prioritisetransaction") => (
+                StatusCode::OK,
+                Json(json!({
+                    "result": true,
+                    "error": null,
+                    "id": "dmnd-client"
+                })),
+            ),
+            Some("getmempoolentry") if state.transaction_in_mempool => (
+                StatusCode::OK,
+                Json(json!({
+                    "result": {},
+                    "error": null,
+                    "id": "dmnd-client"
+                })),
+            ),
+            Some("getmempoolentry") => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "result": null,
+                    "error": {
+                        "code": -5,
+                        "message": "Transaction not in mempool"
+                    },
+                    "id": "dmnd-client"
+                })),
+            ),
+            Some("sendrawtransaction") => (
+                StatusCode::OK,
+                Json(json!({
+                    "result": state.expected_txid,
+                    "error": null,
+                    "id": "dmnd-client"
+                })),
+            ),
+            _ => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "result": null,
+                    "error": {
+                        "code": -32601,
+                        "message": "unknown method"
+                    },
+                    "id": "dmnd-client"
+                })),
+            ),
+        }
+    }
+
+    async fn start_mock_prioritize_bitcoind(
+        transaction_in_mempool: bool,
+    ) -> (BitcoindRpc, UnboundedReceiver<Value>, JoinHandle<()>) {
+        let expected_txid = transaction_from_hex(RAW_TX)
+            .expect("valid test transaction")
+            .compute_txid();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("test server local addr");
+        let (requests, received_requests) = unbounded_channel();
+        let app = Router::new()
+            .route("/", post(mock_prioritize_bitcoind))
+            .with_state(MockPrioritizeState {
+                requests,
+                expected_txid: expected_txid.to_string(),
+                transaction_in_mempool,
+            });
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+        let rpc = BitcoindRpc::new(
+            format!("http://{addr}"),
+            "user".to_string(),
+            "password".to_string(),
+            100_000_000,
+        );
+
+        (rpc, received_requests, server)
+    }
 
     #[test]
     fn detects_bitcoind_not_in_mempool_error() {
@@ -461,90 +576,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_transaction_priority_prioritizes_when_tx_is_already_in_mempool() {
-        #[derive(Clone)]
-        struct MockBitcoindState {
-            requests: UnboundedSender<Value>,
-        }
-
-        async fn mock_bitcoind(
-            State(state): State<MockBitcoindState>,
-            Json(body): Json<Value>,
-        ) -> (StatusCode, Json<Value>) {
-            let method = body
-                .get("method")
-                .and_then(Value::as_str)
-                .map(str::to_owned);
-            state
-                .requests
-                .send(body)
-                .expect("test should receive bitcoind request");
-
-            match method.as_deref() {
-                Some("sendrawtransaction") => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({
-                        "result": null,
-                        "error": {
-                            "code": -27,
-                            "message": "txn-already-in-mempool"
-                        },
-                        "id": "dmnd-client"
-                    })),
-                ),
-                Some("getprioritisedtransactions") => (
-                    StatusCode::OK,
-                    Json(json!({
-                        "result": {},
-                        "error": null,
-                        "id": "dmnd-client"
-                    })),
-                ),
-                Some("prioritisetransaction") => (
-                    StatusCode::OK,
-                    Json(json!({
-                        "result": true,
-                        "error": null,
-                        "id": "dmnd-client"
-                    })),
-                ),
-                _ => (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({
-                        "result": null,
-                        "error": {
-                            "code": -32601,
-                            "message": "unknown method"
-                        },
-                        "id": "dmnd-client"
-                    })),
-                ),
-            }
-        }
-
+    async fn prioritizing_does_not_submit_a_transaction_already_in_mempool() {
         let expected_txid = transaction_from_hex(RAW_TX)
             .expect("valid test transaction")
             .compute_txid();
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("test server should bind");
-        let addr = listener.local_addr().expect("test server local addr");
-        let (requests, mut received_requests) = unbounded_channel();
-        let app = Router::new()
-            .route("/", post(mock_bitcoind))
-            .with_state(MockBitcoindState { requests });
-        let server = tokio::spawn(async move {
-            axum::serve(listener, app)
-                .await
-                .expect("test server should run");
-        });
-
-        let rpc = BitcoindRpc::new(
-            format!("http://{addr}"),
-            "user".to_string(),
-            "password".to_string(),
-            100_000_000,
-        );
+        let (rpc, mut received_requests, server) = start_mock_prioritize_bitcoind(true).await;
 
         let txid = rpc
             .update_transaction_priority(RAW_TX, true)
@@ -552,12 +588,6 @@ mod tests {
             .expect("already-in-mempool tx should still be prioritized");
 
         assert_eq!(txid, expected_txid.to_string());
-
-        let submit_request = received_requests
-            .recv()
-            .await
-            .expect("sendrawtransaction request");
-        assert_eq!(submit_request["method"], "sendrawtransaction");
 
         let priorities_request = received_requests
             .recv()
@@ -573,6 +603,52 @@ mod tests {
         assert_eq!(
             prioritize_request["params"],
             json!([expected_txid, 0, 100_000_000])
+        );
+
+        let mempool_request = received_requests
+            .recv()
+            .await
+            .expect("getmempoolentry request");
+        assert_eq!(mempool_request["method"], "getmempoolentry");
+        assert_eq!(mempool_request["params"], json!([expected_txid]));
+        assert!(
+            received_requests.try_recv().is_err(),
+            "an already-present transaction must not be submitted again"
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn prioritizing_submits_a_missing_transaction_after_applying_the_delta() {
+        let expected_txid = transaction_from_hex(RAW_TX)
+            .expect("valid test transaction")
+            .compute_txid();
+        let (rpc, mut received_requests, server) = start_mock_prioritize_bitcoind(false).await;
+
+        let txid = rpc
+            .update_transaction_priority(RAW_TX, true)
+            .await
+            .expect("missing transaction should be prioritized before it is submitted");
+
+        assert_eq!(txid, expected_txid.to_string());
+
+        let expected_methods = [
+            "getprioritisedtransactions",
+            "prioritisetransaction",
+            "getmempoolentry",
+            "sendrawtransaction",
+        ];
+        for expected_method in expected_methods {
+            let request = received_requests
+                .recv()
+                .await
+                .expect("expected bitcoind request");
+            assert_eq!(request["method"], expected_method);
+        }
+        assert!(
+            received_requests.try_recv().is_err(),
+            "prioritizing a missing transaction should issue exactly four requests"
         );
 
         server.abort();

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -28,7 +28,7 @@ impl BitcoindRpc {
         }
     }
 
-    pub(crate) async fn submit_transaction(
+    pub(crate) async fn update_transaction_priority(
         &self,
         tx: &str,
         prioritize: bool,
@@ -38,13 +38,19 @@ impl BitcoindRpc {
         let _transition_guard = self.priority_transition_lock.lock().await;
         let tx = validate_transaction_hex(tx)?;
         let transaction = transaction_from_hex(tx)?;
-        let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
-        let txid = txid_from_sendrawtransaction_response(&transaction, status, &text)?;
-        let computed_txid = transaction.compute_txid();
-        if txid != computed_txid {
-            return Err(BitcoindRpcError::InvalidResponse(format!(
-                "bitcoind returned txid {txid}, but transaction hex decodes to {computed_txid}"
-            )));
+        let txid = transaction.compute_txid();
+
+        // Prioritizing may introduce a new transaction to the node. Deprioritizing only
+        // reverses an existing virtual fee adjustment, so it must never submit the transaction.
+        if prioritize {
+            let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
+            let submitted_txid =
+                txid_from_sendrawtransaction_response(&transaction, status, &text)?;
+            if submitted_txid != txid {
+                return Err(BitcoindRpcError::InvalidResponse(format!(
+                    "bitcoind returned txid {submitted_txid}, but transaction hex decodes to {txid}"
+                )));
+            }
         }
 
         let current_delta = self.current_fee_delta(&txid).await?;
@@ -455,7 +461,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_transaction_prioritizes_when_tx_is_already_in_mempool() {
+    async fn update_transaction_priority_prioritizes_when_tx_is_already_in_mempool() {
         #[derive(Clone)]
         struct MockBitcoindState {
             requests: UnboundedSender<Value>,
@@ -541,7 +547,7 @@ mod tests {
         );
 
         let txid = rpc
-            .submit_transaction(RAW_TX, true)
+            .update_transaction_priority(RAW_TX, true)
             .await
             .expect("already-in-mempool tx should still be prioritized");
 
@@ -567,6 +573,119 @@ mod tests {
         assert_eq!(
             prioritize_request["params"],
             json!([expected_txid, 0, 100_000_000])
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn deprioritizing_does_not_submit_the_transaction() {
+        #[derive(Clone)]
+        struct MockBitcoindState {
+            requests: UnboundedSender<Value>,
+            prioritized_txid: String,
+        }
+
+        async fn mock_bitcoind(
+            State(state): State<MockBitcoindState>,
+            Json(body): Json<Value>,
+        ) -> (StatusCode, Json<Value>) {
+            let method = body
+                .get("method")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            state
+                .requests
+                .send(body)
+                .expect("test should receive bitcoind request");
+
+            match method.as_deref() {
+                Some("getprioritisedtransactions") => {
+                    let mut priorities = serde_json::Map::new();
+                    priorities.insert(state.prioritized_txid, json!({"fee_delta": 100_000_000}));
+                    (
+                        StatusCode::OK,
+                        Json(json!({
+                            "result": priorities,
+                            "error": null,
+                            "id": "dmnd-client"
+                        })),
+                    )
+                }
+                Some("prioritisetransaction") => (
+                    StatusCode::OK,
+                    Json(json!({
+                        "result": true,
+                        "error": null,
+                        "id": "dmnd-client"
+                    })),
+                ),
+                _ => (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "result": null,
+                        "error": {
+                            "code": -32601,
+                            "message": "unexpected method"
+                        },
+                        "id": "dmnd-client"
+                    })),
+                ),
+            }
+        }
+
+        let expected_txid = transaction_from_hex(RAW_TX)
+            .expect("valid test transaction")
+            .compute_txid();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("test server local addr");
+        let (requests, mut received_requests) = unbounded_channel();
+        let app = Router::new()
+            .route("/", post(mock_bitcoind))
+            .with_state(MockBitcoindState {
+                requests,
+                prioritized_txid: expected_txid.to_string(),
+            });
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+
+        let rpc = BitcoindRpc::new(
+            format!("http://{addr}"),
+            "user".to_string(),
+            "password".to_string(),
+            100_000_000,
+        );
+
+        let txid = rpc
+            .update_transaction_priority(RAW_TX, false)
+            .await
+            .expect("prioritized transaction should be restored to its original fee rate");
+
+        assert_eq!(txid, expected_txid.to_string());
+
+        let priorities_request = received_requests
+            .recv()
+            .await
+            .expect("getprioritisedtransactions request");
+        assert_eq!(priorities_request["method"], "getprioritisedtransactions");
+
+        let deprioritize_request = received_requests
+            .recv()
+            .await
+            .expect("prioritisetransaction request");
+        assert_eq!(deprioritize_request["method"], "prioritisetransaction");
+        assert_eq!(
+            deprioritize_request["params"],
+            json!([expected_txid, 0, -100_000_000])
+        );
+        assert!(
+            received_requests.try_recv().is_err(),
+            "deprioritizing must not send any additional request such as sendrawtransaction"
         );
 
         server.abort();

--- a/src/api/bitcoin_rpc.rs
+++ b/src/api/bitcoin_rpc.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{error::Error as StdError, fmt, time::Duration};
 use tokio::sync::Mutex;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 
 const RPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
@@ -32,7 +32,7 @@ impl BitcoindRpc {
         &self,
         tx: &str,
         prioritize: bool,
-    ) -> Result<String, BitcoindRpcError> {
+    ) -> Result<String, PriorityUpdateError> {
         // Serialize state reads and mutations so concurrent API calls cannot move a transaction
         // outside the two supported states.
         let _transition_guard = self.priority_transition_lock.lock().await;
@@ -45,7 +45,17 @@ impl BitcoindRpc {
         let next_delta = current_delta + delta_to_apply;
 
         if delta_to_apply != 0 {
-            self.prioritise_transaction(&txid, delta_to_apply).await?;
+            self.apply_priority_delta(
+                &transaction,
+                current_delta,
+                delta_to_apply,
+                if prioritize {
+                    PriorityUpdateOperation::Prioritize
+                } else {
+                    PriorityUpdateOperation::Deprioritize
+                },
+            )
+            .await?;
         } else {
             info!(
                 txid = %txid,
@@ -57,22 +67,87 @@ impl BitcoindRpc {
         // Bitcoin Core remembers a priority delta even when the transaction is not in its
         // mempool. Apply the delta first so a low-fee transaction is evaluated with its
         // modified fee when submitted. Deprioritizing never submits the transaction.
-        if prioritize && !self.transaction_in_mempool(&txid.to_string()).await? {
-            let (status, text) = self.send_request("sendrawtransaction", json!([tx])).await?;
-            let submitted_txid =
-                txid_from_sendrawtransaction_response(&transaction, status, &text)?;
-            if submitted_txid != txid {
-                return Err(BitcoindRpcError::InvalidResponse(format!(
-                    "bitcoind returned txid {submitted_txid}, but transaction hex decodes to {txid}"
-                )));
+        if prioritize {
+            let transaction_in_mempool = match self.transaction_in_mempool(&txid.to_string()).await
+            {
+                Ok(in_mempool) => in_mempool,
+                Err(source) => {
+                    return Err(self
+                        .fail_after_priority_applied(
+                            &transaction,
+                            current_delta,
+                            delta_to_apply,
+                            PriorityUpdateOperation::CheckMempool,
+                            source,
+                        )
+                        .await);
+                }
+            };
+
+            if !transaction_in_mempool {
+                let submission_result = async {
+                    let (status, text) =
+                        self.send_request("sendrawtransaction", json!([tx])).await?;
+                    let submitted_txid =
+                        txid_from_sendrawtransaction_response(&transaction, status, &text)?;
+                    if submitted_txid != txid {
+                        return Err(BitcoindRpcError::InvalidResponse(format!(
+                            "bitcoind returned txid {submitted_txid}, but transaction hex decodes to {txid}"
+                        )));
+                    }
+                    Ok(())
+                }
+                .await;
+
+                if let Err(source) = submission_result {
+                    if source.may_have_applied_mutation() {
+                        match self.transaction_in_mempool(&txid.to_string()).await {
+                            Ok(true) => {
+                                warn!(
+                                    txid = %txid,
+                                    error = %source,
+                                    "sendrawtransaction returned an ambiguous error, but reconciliation found the transaction in the mempool"
+                                );
+                            }
+                            Ok(false) => {
+                                return Err(self
+                                    .fail_after_priority_applied(
+                                        &transaction,
+                                        current_delta,
+                                        delta_to_apply,
+                                        PriorityUpdateOperation::Submit,
+                                        source,
+                                    )
+                                    .await);
+                            }
+                            Err(reconciliation_error) => {
+                                return Err(self
+                                    .indeterminate_submission_error(
+                                        &transaction,
+                                        current_delta,
+                                        delta_to_apply,
+                                        source,
+                                        reconciliation_error,
+                                    )
+                                    .await);
+                            }
+                        }
+                    } else {
+                        return Err(self
+                            .fail_after_priority_applied(
+                                &transaction,
+                                current_delta,
+                                delta_to_apply,
+                                PriorityUpdateOperation::Submit,
+                                source,
+                            )
+                            .await);
+                    }
+                }
             }
         }
 
-        if next_delta == self.fee_delta {
-            crate::prioritized_transactions::record(transaction);
-        } else {
-            crate::prioritized_transactions::remove(&txid);
-        }
+        self.sync_transaction_tracking(&transaction, next_delta);
 
         info!(
             txid = %txid,
@@ -83,6 +158,205 @@ impl BitcoindRpc {
             "transaction priority state updated"
         );
         Ok(txid.to_string())
+    }
+
+    async fn apply_priority_delta(
+        &self,
+        transaction: &Transaction,
+        current_delta: i64,
+        delta_to_apply: i64,
+        operation: PriorityUpdateOperation,
+    ) -> Result<(), PriorityUpdateError> {
+        let txid = transaction.compute_txid();
+        let target_delta = current_delta + delta_to_apply;
+        let Err(source) = self.prioritise_transaction(&txid, delta_to_apply).await else {
+            return Ok(());
+        };
+
+        if !source.may_have_applied_mutation() {
+            return Err(PriorityUpdateError::MutationFailed {
+                operation,
+                source,
+                observed_delta: Some(current_delta),
+            });
+        }
+
+        match self.current_fee_delta(&txid).await {
+            Ok(observed_delta) if observed_delta == target_delta => {
+                warn!(
+                    txid = %txid,
+                    %operation,
+                    error = %source,
+                    observed_delta,
+                    "priority mutation returned an ambiguous error, but reconciliation confirmed it succeeded"
+                );
+                self.sync_transaction_tracking(transaction, observed_delta);
+                Ok(())
+            }
+            Ok(observed_delta) if observed_delta == current_delta => {
+                self.sync_transaction_tracking(transaction, observed_delta);
+                Err(PriorityUpdateError::MutationFailed {
+                    operation,
+                    source,
+                    observed_delta: Some(observed_delta),
+                })
+            }
+            Ok(observed_delta) => {
+                self.sync_transaction_tracking(transaction, observed_delta);
+                Err(PriorityUpdateError::StateIndeterminate {
+                    operation,
+                    source,
+                    details: format!(
+                        "reconciliation observed unsupported fee delta {observed_delta}; expected {current_delta} or {target_delta}"
+                    ),
+                })
+            }
+            Err(reconciliation_error) => Err(PriorityUpdateError::StateIndeterminate {
+                operation,
+                source,
+                details: format!(
+                    "could not reconcile the fee delta after the ambiguous error: {reconciliation_error}"
+                ),
+            }),
+        }
+    }
+
+    async fn fail_after_priority_applied(
+        &self,
+        transaction: &Transaction,
+        original_delta: i64,
+        applied_delta: i64,
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+    ) -> PriorityUpdateError {
+        if applied_delta == 0 {
+            return PriorityUpdateError::OperationFailed { operation, source };
+        }
+
+        match self
+            .rollback_priority_delta(transaction, original_delta, applied_delta)
+            .await
+        {
+            RollbackOutcome::Restored => PriorityUpdateError::OperationRolledBack {
+                operation,
+                source,
+            },
+            RollbackOutcome::Failed {
+                rollback_error,
+                observed_delta,
+            } => PriorityUpdateError::RollbackFailed {
+                operation,
+                source,
+                rollback_error,
+                observed_delta,
+            },
+            RollbackOutcome::Indeterminate {
+                rollback_error,
+                reconciliation_error,
+            } => PriorityUpdateError::StateIndeterminate {
+                operation,
+                source,
+                details: format!(
+                    "rollback also failed ambiguously ({rollback_error}), and its result could not be reconciled: {reconciliation_error}"
+                ),
+            },
+        }
+    }
+
+    async fn indeterminate_submission_error(
+        &self,
+        transaction: &Transaction,
+        original_delta: i64,
+        applied_delta: i64,
+        source: BitcoindRpcError,
+        reconciliation_error: BitcoindRpcError,
+    ) -> PriorityUpdateError {
+        let rollback_details = if applied_delta == 0 {
+            "no new priority delta was applied, so no rollback was required".to_string()
+        } else {
+            match self
+                .rollback_priority_delta(transaction, original_delta, applied_delta)
+                .await
+            {
+                RollbackOutcome::Restored => {
+                    "the newly applied priority delta was rolled back".to_string()
+                }
+                RollbackOutcome::Failed {
+                    rollback_error,
+                    observed_delta,
+                } => format!(
+                    "priority rollback failed ({rollback_error}); reconciliation observed fee delta {observed_delta}"
+                ),
+                RollbackOutcome::Indeterminate {
+                    rollback_error,
+                    reconciliation_error,
+                } => format!(
+                    "priority rollback failed ambiguously ({rollback_error}) and could not be reconciled ({reconciliation_error})"
+                ),
+            }
+        };
+
+        PriorityUpdateError::StateIndeterminate {
+            operation: PriorityUpdateOperation::Submit,
+            source,
+            details: format!(
+                "could not determine whether the transaction reached the mempool ({reconciliation_error}); {rollback_details}"
+            ),
+        }
+    }
+
+    async fn rollback_priority_delta(
+        &self,
+        transaction: &Transaction,
+        original_delta: i64,
+        applied_delta: i64,
+    ) -> RollbackOutcome {
+        let txid = transaction.compute_txid();
+        match self.prioritise_transaction(&txid, -applied_delta).await {
+            Ok(()) => {
+                self.sync_transaction_tracking(transaction, original_delta);
+                RollbackOutcome::Restored
+            }
+            Err(rollback_error) => {
+                error!(
+                    txid = %txid,
+                    error = %rollback_error,
+                    "failed to roll back newly applied transaction priority delta"
+                );
+                match self.current_fee_delta(&txid).await {
+                    Ok(observed_delta) if observed_delta == original_delta => {
+                        warn!(
+                            txid = %txid,
+                            error = %rollback_error,
+                            observed_delta,
+                            "priority rollback returned an error, but reconciliation confirmed the original delta was restored"
+                        );
+                        self.sync_transaction_tracking(transaction, observed_delta);
+                        RollbackOutcome::Restored
+                    }
+                    Ok(observed_delta) => {
+                        self.sync_transaction_tracking(transaction, observed_delta);
+                        RollbackOutcome::Failed {
+                            rollback_error,
+                            observed_delta,
+                        }
+                    }
+                    Err(reconciliation_error) => RollbackOutcome::Indeterminate {
+                        rollback_error,
+                        reconciliation_error,
+                    },
+                }
+            }
+        }
+    }
+
+    fn sync_transaction_tracking(&self, transaction: &Transaction, observed_delta: i64) {
+        let txid = transaction.compute_txid();
+        if observed_delta == self.fee_delta {
+            crate::prioritized_transactions::record(transaction.clone());
+        } else if observed_delta == 0 {
+            crate::prioritized_transactions::remove(&txid);
+        }
     }
 
     /// Calculates the adjustment needed to move between the only two supported states:
@@ -157,10 +431,19 @@ impl BitcoindRpc {
             "bitcoind prioritisetransaction response"
         );
 
-        let result = RpcResponse::from_response(status, &text)
-            .map_err(|e| BitcoindRpcError::Prioritize(e.to_string()))?;
+        let response = RpcResponse::decode(status, &text)?;
+        if let Some(error) = response.error {
+            return Err(BitcoindRpcError::Prioritize(format!(
+                "bitcoind RPC error while updating transaction priority: {error}"
+            )));
+        }
+        if !status.is_success() {
+            return Err(BitcoindRpcError::Other(format!(
+                "bitcoind HTTP {status}: {text}"
+            )));
+        }
 
-        match result.and_then(|value| value.as_bool()) {
+        match response.result.and_then(|value| value.as_bool()) {
             Some(true) => Ok(()),
             Some(false) => Err(BitcoindRpcError::Prioritize(format!(
                 "bitcoind returned false for prioritisetransaction: {text}"
@@ -406,6 +689,10 @@ mod tests {
     use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
     use serde_json::json;
     use serde_json::Value;
+    use std::sync::{
+        atomic::{AtomicBool, AtomicI64, Ordering},
+        Arc,
+    };
     use tokio::{
         sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         task::JoinHandle,
@@ -535,6 +822,210 @@ mod tests {
         (rpc, received_requests, server)
     }
 
+    #[derive(Clone, Copy)]
+    enum SubmissionBehavior {
+        Rejected,
+        AmbiguousApplied,
+        AmbiguousNotApplied,
+    }
+
+    #[derive(Clone, Copy)]
+    struct FailurePathConfig {
+        transaction_in_mempool: bool,
+        mempool_check_fails: bool,
+        submission_behavior: SubmissionBehavior,
+        ambiguous_prioritize_response: bool,
+        rollback_fails: bool,
+    }
+
+    #[derive(Clone)]
+    struct FailurePathState {
+        requests: UnboundedSender<Value>,
+        expected_txid: String,
+        fee_delta: Arc<AtomicI64>,
+        transaction_in_mempool: Arc<AtomicBool>,
+        config: FailurePathConfig,
+    }
+
+    fn mock_rpc_response(result: Value, error: Value) -> String {
+        json!({
+            "result": result,
+            "error": error,
+            "id": "dmnd-client"
+        })
+        .to_string()
+    }
+
+    async fn mock_failure_path_bitcoind(
+        State(state): State<FailurePathState>,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, String) {
+        let method = body
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        state
+            .requests
+            .send(body.clone())
+            .expect("test should receive bitcoind request");
+
+        match method.as_deref() {
+            Some("getprioritisedtransactions") => {
+                let fee_delta = state.fee_delta.load(Ordering::SeqCst);
+                let mut priorities = serde_json::Map::new();
+                if fee_delta != 0 {
+                    priorities.insert(
+                        state.expected_txid.clone(),
+                        json!({ "fee_delta": fee_delta }),
+                    );
+                }
+                (
+                    StatusCode::OK,
+                    mock_rpc_response(Value::Object(priorities), Value::Null),
+                )
+            }
+            Some("prioritisetransaction") => {
+                let delta = body
+                    .get("params")
+                    .and_then(Value::as_array)
+                    .and_then(|params| params.get(2))
+                    .and_then(Value::as_i64)
+                    .expect("prioritisetransaction fee delta");
+
+                if delta < 0 && state.config.rollback_fails {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        mock_rpc_response(
+                            Value::Null,
+                            json!({
+                                "code": -1,
+                                "message": "rollback rejected"
+                            }),
+                        ),
+                    );
+                }
+
+                state.fee_delta.fetch_add(delta, Ordering::SeqCst);
+                if delta > 0 && state.config.ambiguous_prioritize_response {
+                    (StatusCode::OK, "{".to_string())
+                } else {
+                    (
+                        StatusCode::OK,
+                        mock_rpc_response(Value::Bool(true), Value::Null),
+                    )
+                }
+            }
+            Some("getmempoolentry") if state.config.mempool_check_fails => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                mock_rpc_response(
+                    Value::Null,
+                    json!({
+                        "code": -1,
+                        "message": "mempool query failed"
+                    }),
+                ),
+            ),
+            Some("getmempoolentry") if state.transaction_in_mempool.load(Ordering::SeqCst) => {
+                (StatusCode::OK, mock_rpc_response(json!({}), Value::Null))
+            }
+            Some("getmempoolentry") => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                mock_rpc_response(
+                    Value::Null,
+                    json!({
+                        "code": -5,
+                        "message": "Transaction not in mempool"
+                    }),
+                ),
+            ),
+            Some("sendrawtransaction") => match state.config.submission_behavior {
+                SubmissionBehavior::Rejected => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    mock_rpc_response(
+                        Value::Null,
+                        json!({
+                            "code": -26,
+                            "message": "mandatory-script-verify-flag-failed"
+                        }),
+                    ),
+                ),
+                SubmissionBehavior::AmbiguousApplied => {
+                    state.transaction_in_mempool.store(true, Ordering::SeqCst);
+                    (StatusCode::OK, "{".to_string())
+                }
+                SubmissionBehavior::AmbiguousNotApplied => (StatusCode::OK, "{".to_string()),
+            },
+            _ => (
+                StatusCode::BAD_REQUEST,
+                mock_rpc_response(
+                    Value::Null,
+                    json!({
+                        "code": -32601,
+                        "message": "unknown method"
+                    }),
+                ),
+            ),
+        }
+    }
+
+    async fn start_failure_path_bitcoind(
+        config: FailurePathConfig,
+    ) -> (
+        BitcoindRpc,
+        UnboundedReceiver<Value>,
+        FailurePathState,
+        JoinHandle<()>,
+    ) {
+        let expected_txid = transaction_from_hex(RAW_TX)
+            .expect("valid test transaction")
+            .compute_txid();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("test server local addr");
+        let (requests, received_requests) = unbounded_channel();
+        let state = FailurePathState {
+            requests,
+            expected_txid: expected_txid.to_string(),
+            fee_delta: Arc::new(AtomicI64::new(0)),
+            transaction_in_mempool: Arc::new(AtomicBool::new(config.transaction_in_mempool)),
+            config,
+        };
+        let app = Router::new()
+            .route("/", post(mock_failure_path_bitcoind))
+            .with_state(state.clone());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+        let rpc = BitcoindRpc::new(
+            format!("http://{addr}"),
+            "user".to_string(),
+            "password".to_string(),
+            100_000_000,
+        );
+
+        (rpc, received_requests, state, server)
+    }
+
+    async fn assert_request_methods(
+        received_requests: &mut UnboundedReceiver<Value>,
+        expected_methods: &[&str],
+    ) {
+        for expected_method in expected_methods {
+            let request = received_requests
+                .recv()
+                .await
+                .expect("expected bitcoind request");
+            assert_eq!(request["method"], *expected_method);
+        }
+        assert!(
+            received_requests.try_recv().is_err(),
+            "mock received an unexpected extra RPC request"
+        );
+    }
+
     #[test]
     fn detects_bitcoind_not_in_mempool_error() {
         let error = json!({
@@ -650,6 +1141,270 @@ mod tests {
             received_requests.try_recv().is_err(),
             "prioritizing a missing transaction should issue exactly four requests"
         );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn definitive_submission_rejection_rolls_back_the_new_delta() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: false,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::Rejected,
+                ambiguous_prioritize_response: false,
+                rollback_fails: false,
+            })
+            .await;
+
+        let error = rpc
+            .update_transaction_priority(RAW_TX, true)
+            .await
+            .expect_err("rejected transaction submission should fail");
+
+        assert!(matches!(
+            error,
+            super::PriorityUpdateError::OperationRolledBack {
+                operation: super::PriorityUpdateOperation::Submit,
+                ..
+            }
+        ));
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 0);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getmempoolentry",
+                "sendrawtransaction",
+                "prioritisetransaction",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn mempool_check_failure_rolls_back_the_new_delta() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: false,
+                mempool_check_fails: true,
+                submission_behavior: SubmissionBehavior::Rejected,
+                ambiguous_prioritize_response: false,
+                rollback_fails: false,
+            })
+            .await;
+
+        let error = rpc
+            .update_transaction_priority(RAW_TX, true)
+            .await
+            .expect_err("mempool query failure should fail the update");
+
+        assert!(matches!(
+            error,
+            super::PriorityUpdateError::OperationRolledBack {
+                operation: super::PriorityUpdateOperation::CheckMempool,
+                ..
+            }
+        ));
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 0);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getmempoolentry",
+                "prioritisetransaction",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ambiguous_submission_error_is_success_when_reconciliation_finds_the_transaction() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: false,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::AmbiguousApplied,
+                ambiguous_prioritize_response: false,
+                rollback_fails: false,
+            })
+            .await;
+
+        rpc.update_transaction_priority(RAW_TX, true)
+            .await
+            .expect("mempool reconciliation should confirm submission");
+
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 100_000_000);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getmempoolentry",
+                "sendrawtransaction",
+                "getmempoolentry",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ambiguous_submission_error_rolls_back_when_reconciliation_finds_no_transaction() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: false,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::AmbiguousNotApplied,
+                ambiguous_prioritize_response: false,
+                rollback_fails: false,
+            })
+            .await;
+
+        let error = rpc
+            .update_transaction_priority(RAW_TX, true)
+            .await
+            .expect_err("unconfirmed transaction submission should fail");
+
+        assert!(matches!(
+            error,
+            super::PriorityUpdateError::OperationRolledBack {
+                operation: super::PriorityUpdateOperation::Submit,
+                ..
+            }
+        ));
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 0);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getmempoolentry",
+                "sendrawtransaction",
+                "getmempoolentry",
+                "prioritisetransaction",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ambiguous_prioritization_error_is_reconciled_before_submission() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: true,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::Rejected,
+                ambiguous_prioritize_response: true,
+                rollback_fails: false,
+            })
+            .await;
+
+        rpc.update_transaction_priority(RAW_TX, true)
+            .await
+            .expect("fee delta reconciliation should confirm prioritization");
+
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 100_000_000);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getprioritisedtransactions",
+                "getmempoolentry",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_rollback_reports_the_retained_delta() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: false,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::Rejected,
+                ambiguous_prioritize_response: false,
+                rollback_fails: true,
+            })
+            .await;
+
+        let error = rpc
+            .update_transaction_priority(RAW_TX, true)
+            .await
+            .expect_err("submission and rollback failures should be reported");
+        let error_message = error.to_string();
+
+        assert!(matches!(
+            error,
+            super::PriorityUpdateError::RollbackFailed {
+                operation: super::PriorityUpdateOperation::Submit,
+                observed_delta: 100_000_000,
+                ..
+            }
+        ));
+        assert!(error_message.contains("priority rollback failed"));
+        assert!(error_message.contains("fee delta 100000000"));
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 100_000_000);
+        assert_request_methods(
+            &mut received_requests,
+            &[
+                "getprioritisedtransactions",
+                "prioritisetransaction",
+                "getmempoolentry",
+                "sendrawtransaction",
+                "prioritisetransaction",
+                "getprioritisedtransactions",
+            ],
+        )
+        .await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_deprioritization_returns_an_error_and_keeps_the_observed_delta() {
+        let (rpc, mut received_requests, state, server) =
+            start_failure_path_bitcoind(FailurePathConfig {
+                transaction_in_mempool: true,
+                mempool_check_fails: false,
+                submission_behavior: SubmissionBehavior::Rejected,
+                ambiguous_prioritize_response: false,
+                rollback_fails: true,
+            })
+            .await;
+        state.fee_delta.store(100_000_000, Ordering::SeqCst);
+
+        let error = rpc
+            .update_transaction_priority(RAW_TX, false)
+            .await
+            .expect_err("rejected deprioritization should fail");
+
+        assert!(matches!(
+            error,
+            super::PriorityUpdateError::MutationFailed {
+                operation: super::PriorityUpdateOperation::Deprioritize,
+                observed_delta: Some(100_000_000),
+                ..
+            }
+        ));
+        assert_eq!(state.fee_delta.load(Ordering::SeqCst), 100_000_000);
+        assert_request_methods(
+            &mut received_requests,
+            &["getprioritisedtransactions", "prioritisetransaction"],
+        )
+        .await;
 
         server.abort();
     }
@@ -816,6 +1571,15 @@ impl BitcoindRpcError {
             | BitcoindRpcError::Prioritize(_) => StatusCode::BAD_GATEWAY,
         }
     }
+
+    fn may_have_applied_mutation(&self) -> bool {
+        matches!(
+            self,
+            BitcoindRpcError::Timeout(_)
+                | BitcoindRpcError::Other(_)
+                | BitcoindRpcError::InvalidResponse(_)
+        )
+    }
 }
 
 impl From<reqwest::Error> for BitcoindRpcError {
@@ -849,4 +1613,130 @@ impl fmt::Display for BitcoindRpcError {
             | BitcoindRpcError::Prioritize(msg) => f.write_str(msg),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PriorityUpdateOperation {
+    Prioritize,
+    Deprioritize,
+    CheckMempool,
+    Submit,
+}
+
+impl fmt::Display for PriorityUpdateOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            PriorityUpdateOperation::Prioritize => "prioritisetransaction",
+            PriorityUpdateOperation::Deprioritize => "deprioritizing transaction",
+            PriorityUpdateOperation::CheckMempool => "getmempoolentry",
+            PriorityUpdateOperation::Submit => "sendrawtransaction",
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum PriorityUpdateError {
+    Rpc(BitcoindRpcError),
+    MutationFailed {
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+        observed_delta: Option<i64>,
+    },
+    OperationFailed {
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+    },
+    OperationRolledBack {
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+    },
+    RollbackFailed {
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+        rollback_error: BitcoindRpcError,
+        observed_delta: i64,
+    },
+    StateIndeterminate {
+        operation: PriorityUpdateOperation,
+        source: BitcoindRpcError,
+        details: String,
+    },
+}
+
+impl PriorityUpdateError {
+    pub(crate) fn status_code(&self) -> StatusCode {
+        match self {
+            PriorityUpdateError::Rpc(source)
+            | PriorityUpdateError::MutationFailed { source, .. }
+            | PriorityUpdateError::OperationFailed { source, .. }
+            | PriorityUpdateError::OperationRolledBack { source, .. } => source.status_code(),
+            PriorityUpdateError::RollbackFailed { .. }
+            | PriorityUpdateError::StateIndeterminate { .. } => StatusCode::BAD_GATEWAY,
+        }
+    }
+}
+
+impl From<BitcoindRpcError> for PriorityUpdateError {
+    fn from(error: BitcoindRpcError) -> Self {
+        PriorityUpdateError::Rpc(error)
+    }
+}
+
+impl fmt::Display for PriorityUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PriorityUpdateError::Rpc(source) => source.fmt(f),
+            PriorityUpdateError::MutationFailed {
+                operation,
+                source,
+                observed_delta,
+            } => {
+                write!(f, "{operation} failed: {source}")?;
+                if let Some(observed_delta) = observed_delta {
+                    write!(
+                        f,
+                        "; reconciliation observed fee delta {observed_delta}"
+                    )?;
+                }
+                Ok(())
+            }
+            PriorityUpdateError::OperationFailed { operation, source } => {
+                write!(f, "{operation} failed: {source}")
+            }
+            PriorityUpdateError::OperationRolledBack { operation, source } => write!(
+                f,
+                "{operation} failed: {source}; the newly applied priority delta was rolled back"
+            ),
+            PriorityUpdateError::RollbackFailed {
+                operation,
+                source,
+                rollback_error,
+                observed_delta,
+            } => write!(
+                f,
+                "{operation} failed: {source}; priority rollback failed: {rollback_error}; reconciliation observed fee delta {observed_delta}"
+            ),
+            PriorityUpdateError::StateIndeterminate {
+                operation,
+                source,
+                details,
+            } => write!(
+                f,
+                "{operation} failed ambiguously: {source}; final state is indeterminate: {details}"
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RollbackOutcome {
+    Restored,
+    Failed {
+        rollback_error: BitcoindRpcError,
+        observed_delta: i64,
+    },
+    Indeterminate {
+        rollback_error: BitcoindRpcError,
+        reconciliation_error: BitcoindRpcError,
+    },
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -62,7 +62,10 @@ pub(crate) async fn start(
             "/api/merge-mining/found-job",
             get(crate::merge_mining::poll_found_job_api),
         )
-        .route("/api/tx/submit/{tx}", post(Api::send_tx_to_bitcoind))
+        .route(
+            "/api/tx/submit/{action}/{tx}",
+            post(Api::send_tx_to_bitcoind),
+        )
         .route(
             "/api/tx/prioritized",
             get(Api::get_prioritized_transactions),

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -157,8 +157,21 @@ impl Api {
     pub async fn send_tx_to_bitcoind(
         State(state): State<AppState>,
         headers: HeaderMap,
-        Path(tx): Path<String>,
+        Path((action, tx)): Path<(String, String)>,
     ) -> impl IntoResponse {
+        let prioritize = match action.as_str() {
+            "+" => true,
+            "-" => false,
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(APIResponse::<String>::error(Some(
+                        "transaction priority action must be '+' or '-'".to_string(),
+                    ))),
+                )
+            }
+        };
+
         let Some(prioritizing_txs) = state.prioritizing_txs.as_ref() else {
             warn!("PRIORITIZING TXS NOT ENABLED");
             return (
@@ -179,9 +192,13 @@ impl Api {
             );
         }
 
-        match prioritizing_txs.rpc.submit_transaction(&tx).await {
+        match prioritizing_txs
+            .rpc
+            .submit_transaction(&tx, prioritize)
+            .await
+        {
             Ok(txid) => {
-                info!("transaction sent to bitcoind: {txid}");
+                info!(%txid, prioritize, "transaction sent to bitcoind");
                 (StatusCode::OK, Json(APIResponse::success(Some(txid))))
             }
             Err(e) => {
@@ -373,7 +390,7 @@ async fn send_tx_reports_unavailable_when_rpc_is_disabled() {
     let response = Api::send_tx_to_bitcoind(
         State(state),
         axum::http::HeaderMap::new(),
-        Path("00".to_string()),
+        Path(("+".to_string(), "00".to_string())),
     )
     .await
     .into_response();
@@ -409,7 +426,7 @@ async fn send_tx_rejects_missing_api_tx_token_header() {
     let response = Api::send_tx_to_bitcoind(
         State(state),
         axum::http::HeaderMap::new(),
-        Path("00".to_string()),
+        Path(("+".to_string(), "00".to_string())),
     )
     .await
     .into_response();

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -194,15 +194,15 @@ impl Api {
 
         match prioritizing_txs
             .rpc
-            .submit_transaction(&tx, prioritize)
+            .update_transaction_priority(&tx, prioritize)
             .await
         {
             Ok(txid) => {
-                info!(%txid, prioritize, "transaction sent to bitcoind");
+                info!(%txid, prioritize, "transaction priority request completed");
                 (StatusCode::OK, Json(APIResponse::success(Some(txid))))
             }
             Err(e) => {
-                error!("Failed to send transaction to bitcoind: {e}");
+                error!("Failed to update transaction priority: {e}");
                 (
                     e.status_code(),
                     Json(APIResponse::error(Some(e.to_string()))),

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,10 +326,12 @@ and make that test pass."
             return (None, missing);
         }
 
-        let fee_delta = match fee_delta.trim().parse() {
-            Ok(fee_delta) => fee_delta,
-            Err(_) => return (None, vec!["RPC_FEE_DELTA"]),
+        let Ok(fee_delta) = fee_delta.trim().parse() else {
+            return (None, vec!["RPC_FEE_DELTA"]);
         };
+        if fee_delta <= 0 {
+            return (None, vec!["RPC_FEE_DELTA"]);
+        }
 
         (
             Some(BitcoindRpcConfig {
@@ -1194,5 +1196,21 @@ mod tests {
                 "API_TX_TOKEN"
             ]
         );
+    }
+
+    #[test]
+    fn prioritizing_txs_requires_a_positive_fee_delta() {
+        for fee_delta in ["0", "-100000000", "not-a-number"] {
+            let (config, missing) = Configuration::build_prioritizing_txs_config(
+                "http://127.0.0.1:8332".to_string(),
+                "user".to_string(),
+                "password".to_string(),
+                fee_delta.to_string(),
+                "api-token".to_string(),
+            );
+
+            assert!(config.is_none());
+            assert_eq!(missing, vec!["RPC_FEE_DELTA"]);
+        }
     }
 }


### PR DESCRIPTION
Add logic for deprioritizing transactions.
The txs will have two states: nomal, 0 fee_delta and prioritized, with 1btc fee_delta. This pr makes possible to jump from one state to another via an api controller